### PR TITLE
feat: add Obsidian diary Git skill

### DIFF
--- a/skills/productivity/obsidian-diary-git/SKILL.md
+++ b/skills/productivity/obsidian-diary-git/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: obsidian-diary-git
+description: Save diary entries as Obsidian-compatible Markdown in a Git-backed vault clone on a dedicated branch. Use for Hermes daily diary capture and approved diary writes.
+version: 0.1.0
+author: backup-secretary
+license: MIT
+metadata:
+  hermes:
+    tags: [obsidian, diary, git, markdown, personal-knowledge]
+    related_skills: [obsidian, write-and-forget-capture]
+---
+
+# Obsidian Diary Git
+
+## Purpose
+
+Write private diary entries to an Obsidian vault repo as Markdown, without putting diary text into Hermes standard memory.
+
+This skill intentionally uses a **Git clone under persistent Hermes data** instead of requiring an extra Docker bind mount. In the user's backup-secretary deployment, `/opt/data` is already persistent, so the default clone path survives container restarts:
+
+```text
+/opt/data/obsidian/obsidian_git
+```
+
+## Branch policy
+
+Use a dedicated branch:
+
+```text
+hermes
+```
+
+Do **not** write diary entries to `main`. The `hermes` branch is intentionally allowed to be messy/breakable while the workflow stabilizes.
+
+## Default repo
+
+User-provided Obsidian repo:
+
+```text
+git@github.com:ktakahiro150397/obsidian_git.git
+```
+
+In the current container, SSH auth may be unavailable. `gh` auth works with HTTPS, so the live clone can use:
+
+```text
+https://github.com/ktakahiro150397/obsidian_git.git
+```
+
+## Commands
+
+From the skill directory:
+
+```bash
+python3 scripts/obsidian_diary.py status
+python3 scripts/obsidian_diary.py save "今日はHermesの日記保存を試した" --source hermes-discord --tags diary,hermes
+python3 scripts/obsidian_diary.py save "pushせずに検証" --no-push --no-pull
+```
+
+Explicit vault/repo/branch:
+
+```bash
+python3 scripts/obsidian_diary.py \
+  --vault /opt/data/obsidian/obsidian_git \
+  --repo https://github.com/ktakahiro150397/obsidian_git.git \
+  --branch hermes \
+  save "日記本文" --source hermes-discord --tags diary
+```
+
+## File layout
+
+Diary files are created here:
+
+```text
+10_Diary/YYYY/MM/YYYY-MM-DD.md
+```
+
+New files get Obsidian/Dataview-friendly frontmatter:
+
+```yaml
+---
+type: diary
+date: YYYY-MM-DD
+weekday: Wednesday
+created: YYYY-MM-DDTHH:mm:ss+09:00
+updated: YYYY-MM-DDTHH:mm:ss+09:00
+tags:
+  - diary
+people: []
+topics: []
+tasks: []
+private: true
+source: hermes-discord
+---
+```
+
+Subsequent entries append a timestamped section:
+
+```markdown
+## HH:MM Hermes
+
+<!-- source: hermes-discord / #tag -->
+
+本文
+```
+
+## Git behavior
+
+On `save`:
+
+1. Ensure the vault repo exists; clone from `--repo` if missing.
+2. Ensure the current branch is `hermes`.
+3. `git fetch origin --prune`.
+4. If `origin/hermes` exists, `git pull --rebase --autostash origin hermes`.
+5. Create/append the diary Markdown file.
+6. `git add <diary-file>`.
+7. `git commit -m "diary: YYYY-MM-DD"`.
+8. `git push -u origin hermes` unless `--no-push` is specified.
+
+If pull/commit/push fails, do not auto-resolve conflicts. Report the failing command and repo path.
+
+## Safety rules
+
+- Never write to `main` for diary entries.
+- Never store diary body in Hermes `MEMORY.md` / `USER.md`.
+- Keep OAuth tokens, `.env`, `.obsidian/workspace*.json`, and plugin data out of committed diary changes.
+- Prefer `--no-push --no-pull` for smoke tests.
+- Use `hermes` branch until the format is proven stable.
+
+## Tests
+
+From the repository root:
+
+```bash
+uv run --with pytest python -m pytest tests/test_obsidian_diary.py -q
+```

--- a/skills/productivity/obsidian-diary-git/scripts/obsidian_diary.py
+++ b/skills/productivity/obsidian-diary-git/scripts/obsidian_diary.py
@@ -110,7 +110,18 @@ def parse_tags(raw: str | None) -> list[str]:
     return tags
 
 
+def unique_values(values: list[str]) -> list[str]:
+    unique: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value not in seen:
+            unique.append(value)
+            seen.add(value)
+    return unique
+
+
 def yaml_list(values: list[str], indent: str = "  ") -> str:
+    values = unique_values(values)
     if not values:
         return "[]"
     return "\n" + "\n".join(f"{indent}- {value}" for value in values)

--- a/skills/productivity/obsidian-diary-git/scripts/obsidian_diary.py
+++ b/skills/productivity/obsidian-diary-git/scripts/obsidian_diary.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Git-backed Obsidian diary writer for Hermes.
+
+Writes diary entries to an Obsidian vault clone on a dedicated branch, then
+commits and optionally pushes the change. Intended default location is the
+persistent Hermes home, not a separate Docker bind mount.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+DEFAULT_VAULT = Path(os.environ.get("OBSIDIAN_VAULT_PATH", "/opt/data/obsidian/obsidian_git"))
+DEFAULT_BRANCH = os.environ.get("OBSIDIAN_DIARY_BRANCH", "hermes")
+DEFAULT_REPO = os.environ.get("OBSIDIAN_REPO_URL", "")
+DEFAULT_DIARY_DIR = os.environ.get("OBSIDIAN_DIARY_DIR", "10_Diary")
+JST = ZoneInfo("Asia/Tokyo")
+
+
+class DiaryError(RuntimeError):
+    pass
+
+
+def emit(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+
+
+def run_git(vault: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=vault,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if check and proc.returncode != 0:
+        command = "git " + " ".join(args)
+        detail = (proc.stderr or proc.stdout).strip()
+        raise DiaryError(f"{command} failed: {detail}")
+    return proc
+
+
+def ensure_vault(vault: Path, repo: str | None = None) -> None:
+    if (vault / ".git").is_dir():
+        return
+    if vault.exists() and any(vault.iterdir()):
+        raise DiaryError(f"vault path exists but is not a git repo: {vault}")
+    if not repo:
+        raise DiaryError(f"vault is missing and no repo URL was provided: {vault}")
+    vault.parent.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        ["git", "clone", repo, str(vault)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout).strip()
+        raise DiaryError(f"git clone failed: {detail}")
+
+
+def current_branch(vault: Path) -> str:
+    return run_git(vault, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+
+
+def remote_branch_exists(vault: Path, branch: str) -> bool:
+    proc = run_git(vault, "ls-remote", "--exit-code", "--heads", "origin", branch, check=False)
+    return proc.returncode == 0
+
+
+def ensure_branch(vault: Path, branch: str) -> None:
+    if current_branch(vault) == branch:
+        return
+    local = run_git(vault, "show-ref", "--verify", "--quiet", f"refs/heads/{branch}", check=False)
+    if local.returncode == 0:
+        run_git(vault, "checkout", branch)
+    elif remote_branch_exists(vault, branch):
+        run_git(vault, "checkout", "-b", branch, f"origin/{branch}")
+    else:
+        run_git(vault, "checkout", "-b", branch)
+
+
+def sync_before_write(vault: Path, branch: str, *, skip_pull: bool) -> None:
+    ensure_branch(vault, branch)
+    if skip_pull:
+        return
+    run_git(vault, "fetch", "origin", "--prune")
+    if remote_branch_exists(vault, branch):
+        run_git(vault, "pull", "--rebase", "--autostash", "origin", branch)
+
+
+def parse_tags(raw: str | None) -> list[str]:
+    if not raw:
+        return []
+    tags: list[str] = []
+    seen: set[str] = set()
+    for part in raw.split(","):
+        tag = part.strip().lstrip("#")
+        if tag and tag not in seen:
+            tags.append(tag)
+            seen.add(tag)
+    return tags
+
+
+def yaml_list(values: list[str], indent: str = "  ") -> str:
+    if not values:
+        return "[]"
+    return "\n" + "\n".join(f"{indent}- {value}" for value in values)
+
+
+def diary_path(vault: Path, diary_dir: str, day: datetime) -> Path:
+    return vault / diary_dir / day.strftime("%Y") / day.strftime("%m") / f"{day:%Y-%m-%d}.md"
+
+
+def create_entry_file(path: Path, day: datetime, now: datetime, source: str, tags: list[str]) -> None:
+    weekday = day.strftime("%A")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = f"""---
+type: diary
+date: {day:%Y-%m-%d}
+weekday: {weekday}
+created: {now.isoformat(timespec="seconds")}
+updated: {now.isoformat(timespec="seconds")}
+tags:{yaml_list(["diary", *tags])}
+people: []
+topics: []
+tasks: []
+private: true
+source: {source}
+---
+
+# {day:%Y-%m-%d} 日記
+
+"""
+    path.write_text(content, encoding="utf-8")
+
+
+def update_frontmatter_timestamp(path: Path, now: datetime) -> None:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return
+    front = text[:end]
+    rest = text[end:]
+    lines = front.splitlines()
+    updated = False
+    for idx, line in enumerate(lines):
+        if line.startswith("updated:"):
+            lines[idx] = f"updated: {now.isoformat(timespec='seconds')}"
+            updated = True
+            break
+    if not updated:
+        lines.append(f"updated: {now.isoformat(timespec='seconds')}")
+    path.write_text("\n".join(lines) + rest, encoding="utf-8")
+
+
+def append_entry(path: Path, body: str, now: datetime, source: str, tags: list[str]) -> None:
+    tag_text = " ".join(f"#{tag}" for tag in tags)
+    meta = f"source: {source}"
+    if tag_text:
+        meta += f" / {tag_text}"
+    block = f"\n## {now.strftime('%H:%M')} Hermes\n\n<!-- {meta} -->\n\n{body.strip()}\n"
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(block)
+
+
+def has_changes(vault: Path) -> bool:
+    proc = run_git(vault, "status", "--porcelain")
+    return bool(proc.stdout.strip())
+
+
+def commit_and_push(vault: Path, rel_path: str, date_text: str, branch: str, *, no_push: bool) -> dict[str, Any]:
+    run_git(vault, "add", rel_path)
+    if not has_changes(vault):
+        return {"committed": False, "commit": None, "pushed": False}
+    run_git(vault, "commit", "-m", f"diary: {date_text}")
+    commit = run_git(vault, "rev-parse", "HEAD").stdout.strip()
+    pushed = False
+    if not no_push:
+        run_git(vault, "push", "-u", "origin", branch)
+        pushed = True
+    return {"committed": True, "commit": commit, "pushed": pushed}
+
+
+def save_diary(args: argparse.Namespace) -> dict[str, Any]:
+    vault = args.vault.resolve()
+    ensure_vault(vault, args.repo or None)
+    sync_before_write(vault, args.branch, skip_pull=args.no_pull)
+
+    now = datetime.now(JST)
+    day = datetime.strptime(args.date, "%Y-%m-%d").replace(tzinfo=JST) if args.date else now
+    tags = parse_tags(args.tags)
+    path = diary_path(vault, args.diary_dir, day)
+    if path.exists():
+        update_frontmatter_timestamp(path, now)
+    else:
+        create_entry_file(path, day, now, args.source, tags)
+    append_entry(path, args.body, now, args.source, tags)
+
+    rel_path = path.relative_to(vault).as_posix()
+    git_result = commit_and_push(vault, rel_path, day.strftime("%Y-%m-%d"), args.branch, no_push=args.no_push)
+    return {
+        "status": "saved",
+        "vault": str(vault),
+        "branch": args.branch,
+        "path": rel_path,
+        **git_result,
+    }
+
+
+def status(args: argparse.Namespace) -> dict[str, Any]:
+    vault = args.vault.resolve()
+    ensure_vault(vault, args.repo or None)
+    branch = current_branch(vault)
+    proc = run_git(vault, "status", "--porcelain")
+    return {"status": "ok", "vault": str(vault), "branch": branch, "dirty": bool(proc.stdout.strip())}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Save diary entries to a Git-backed Obsidian vault")
+    parser.add_argument("--vault", type=Path, default=DEFAULT_VAULT, help=f"Vault clone path (default: {DEFAULT_VAULT})")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="Repo URL used when --vault is not cloned yet")
+    parser.add_argument("--branch", default=DEFAULT_BRANCH, help=f"Diary branch (default: {DEFAULT_BRANCH})")
+    parser.add_argument("--diary-dir", default=DEFAULT_DIARY_DIR, help=f"Diary root directory in vault (default: {DEFAULT_DIARY_DIR})")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    save = sub.add_parser("save", help="Append a diary entry and commit it")
+    save.add_argument("body", help="Diary body markdown")
+    save.add_argument("--date", help="Diary date YYYY-MM-DD; defaults to today in JST")
+    save.add_argument("--source", default="hermes-discord", help="Source label")
+    save.add_argument("--tags", default="", help="Comma-separated tags, without or with #")
+    save.add_argument("--no-pull", action="store_true", help="Skip fetch/pull before writing")
+    save.add_argument("--no-push", action="store_true", help="Commit locally but do not push")
+
+    stat = sub.add_parser("status", help="Show vault status")
+    stat.set_defaults(func=status)
+    save.set_defaults(func=save_diary)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        emit(args.func(args))
+    except (DiaryError, OSError, ValueError) as exc:
+        parser.exit(2, f"error: {exc}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_obsidian_diary.py
+++ b/tests/test_obsidian_diary.py
@@ -1,0 +1,128 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "skills" / "productivity" / "obsidian-diary-git" / "scripts" / "obsidian_diary.py"
+
+
+def git(cwd: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip()
+
+
+def init_repo(path: Path) -> None:
+    path.mkdir(parents=True)
+    git(path, "init", "-b", "main")
+    git(path, "config", "user.email", "test@example.com")
+    git(path, "config", "user.name", "Test User")
+    (path / "README.md").write_text("# vault\n", encoding="utf-8")
+    git(path, "add", "README.md")
+    git(path, "commit", "-m", "init")
+
+
+def run_diary(vault: Path, *args: str):
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(CLI),
+            "--vault",
+            str(vault),
+            "--branch",
+            "hermes",
+            *args,
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def test_save_creates_dated_markdown_on_hermes_branch(tmp_path):
+    vault = tmp_path / "vault"
+    init_repo(vault)
+
+    payload = run_diary(
+        vault,
+        "save",
+        "今日はHermesの日記保存を試した",
+        "--date",
+        "2026-04-29",
+        "--source",
+        "hermes-discord",
+        "--tags",
+        "hermes,diary",
+        "--no-pull",
+        "--no-push",
+    )
+
+    assert payload["status"] == "saved"
+    assert payload["branch"] == "hermes"
+    assert payload["path"] == "10_Diary/2026/04/2026-04-29.md"
+    assert payload["committed"] is True
+    assert payload["pushed"] is False
+    assert git(vault, "rev-parse", "--abbrev-ref", "HEAD") == "hermes"
+
+    diary = vault / payload["path"]
+    text = diary.read_text(encoding="utf-8")
+    assert "type: diary" in text
+    assert "date: 2026-04-29" in text
+    assert "source: hermes-discord" in text
+    assert "- diary" in text
+    assert "- hermes" in text
+    assert "今日はHermesの日記保存を試した" in text
+
+
+def test_save_appends_to_existing_day_and_updates_timestamp(tmp_path):
+    vault = tmp_path / "vault"
+    init_repo(vault)
+
+    first = run_diary(vault, "save", "一回目", "--date", "2026-04-29", "--no-pull", "--no-push")
+    second = run_diary(vault, "save", "二回目", "--date", "2026-04-29", "--no-pull", "--no-push")
+
+    assert first["path"] == second["path"]
+    text = (vault / second["path"]).read_text(encoding="utf-8")
+    assert text.count("## ") >= 2
+    assert "一回目" in text
+    assert "二回目" in text
+    assert "updated:" in text
+
+
+def test_status_reports_branch_and_dirty_state(tmp_path):
+    vault = tmp_path / "vault"
+    init_repo(vault)
+    git(vault, "checkout", "-b", "hermes")
+
+    payload = run_diary(vault, "status")
+
+    assert payload == {
+        "status": "ok",
+        "vault": str(vault.resolve()),
+        "branch": "hermes",
+        "dirty": False,
+    }
+
+
+def test_rejects_missing_vault_without_repo(tmp_path):
+    vault = tmp_path / "missing"
+    proc = subprocess.run(
+        [sys.executable, str(CLI), "--vault", str(vault), "save", "本文", "--no-pull", "--no-push"],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert proc.returncode == 2
+    assert "vault is missing and no repo URL was provided" in proc.stderr

--- a/tests/test_obsidian_diary.py
+++ b/tests/test_obsidian_diary.py
@@ -79,7 +79,7 @@ def test_save_creates_dated_markdown_on_hermes_branch(tmp_path):
     assert "type: diary" in text
     assert "date: 2026-04-29" in text
     assert "source: hermes-discord" in text
-    assert "- diary" in text
+    assert text.count("  - diary") == 1
     assert "- hermes" in text
     assert "今日はHermesの日記保存を試した" in text
 


### PR DESCRIPTION
## 概要

Issue #8 の実装として、Git-backed Obsidian diary 保存用 skill を追加しました。

- `/opt/data/obsidian/obsidian_git` をデフォルト vault clone として扱う
- `main` ではなく `hermes` ブランチへ保存する
- `10_Diary/YYYY/MM/YYYY-MM-DD.md` に YAML frontmatter 付き Markdown を作成/追記する
- 保存時に `git fetch` / `pull --rebase --autostash` / `commit` / `push -u origin hermes` を行う
- bind mount は不要。既存の persistent `/opt/data` 配下に clone する方針

## 検証

```bash
uv run --with pytest python -m pytest tests/test_obsidian_diary.py tests/test_waf.py -q
# 9 passed
```

## 補足

Obsidian repo 側は `/opt/data/obsidian/obsidian_git` に clone 済みで、`hermes` ブランチも remote に作成済みです。

Closes #8
