### PR TITLE
Add Scrapling for web extraction fallback

### DIFF
--- a/docker/hermes/Dockerfile
+++ b/docker/hermes/Dockerfile
@@ -12,6 +12,8 @@ RUN set -eux; \
   npm install -g @openai/codex; \
   npm install -g @anthropic-ai/claude-code; \
   npm cache clean --force; \
+  # Install Scrapling for web extraction fallback (stealthy_fetch / fetch for JS-required & bot-protected sites)
+  . /opt/hermes/.venv/bin/activate && uv pip install --no-cache-dir "scrapling[ai]"; \
   if [ "$HERMES_GID" != "$(id -g hermes)" ]; then \
   groupmod -o -g "$HERMES_GID" hermes; \
   fi; \


### PR DESCRIPTION
## Summary

Installs `scrapling[ai]` into the Hermes base venv to enable `stealthy_fetch` / `fetch` as a fallback when the lightweight `web_extract` fails on JS-required or bot-protected sites (e.g. X/Twitter, Cloudflare).

## Changes

- `docker/hermes/Dockerfile`: adds `uv pip install "scrapling[ai]"` after npm setup

## Why

- `web_extract` (curl/HTTP-only) cannot render JS SPAs or bypass anti-bot protections
- Scrapling provides Playwright-based `fetch` / `stealthy_fetch` for these cases
- The base image already includes Chromium (`npx playwright install --with-deps chromium --only-shell`), so Scrapling works out of the box once the Python package is installed

## Verification

Tested manually in the running container:
- `StealthyFetcher.fetch(url, headless=True, network_idle=True)` successfully extracted text from an X post that `web_extract` failed to parse

## Trade-offs

- Adds ~50MB+ of Python dependencies to the image
- Browser-based fetching has higher latency (~2-5s startup) and RAM usage; only used as a fallback, not for every request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build configuration to include required dependencies for AI-powered features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->