### PR TITLE
feat: add shared SearXNG and Valkey search stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,12 +17,17 @@ HERMES_GID=1000
 # OpenViking公式image
 OPENVIKING_IMAGE=ghcr.io/volcengine/openviking:latest
 
+# SearXNG / Valkey images
+SEARXNG_IMAGE=docker.io/searxng/searxng:latest
+VALKEY_IMAGE=docker.io/valkey/valkey:8-alpine
+
 # Host paths
 HERMES_MAIN_DATA_DIR=./runtime/main/hermes-data
 HERMES_OWASHOTA_DATA_DIR=./runtime/owashota/hermes-data
 HERMES_WORKSPACE_DIR=./workspace
 OPENVIKING_DATA_DIR=./runtime/openviking
 OPENVIKING_ENV_FILE=./runtime/openviking/.env
+SEARXNG_CONFIG_DIR=./config/searxng
 
 # Instance env files loaded into each Hermes container.
 # These files are not committed.
@@ -40,3 +45,15 @@ HERMES_OWASHOTA_GATEWAY_PORT=8643
 OPENVIKING_BIND=127.0.0.1
 OPENVIKING_PORT=1933
 OPENVIKING_WITH_BOT=0
+
+# SearXNG HTTP server. Hermes reaches it internally at http://searxng:8080.
+# The host port is for local diagnostics only.
+SEARXNG_BIND=127.0.0.1
+SEARXNG_PORT=8080
+SEARXNG_BASE_URL=http://searxng:8080/
+
+# Optional resource limits.
+SEARXNG_MEMORY_LIMIT=512m
+SEARXNG_CPU_LIMIT=0.5
+VALKEY_MEMORY_LIMIT=128m
+VALKEY_CPU_LIMIT=0.25

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,7 @@ x-hermes-environment: &hermes-environment
   HOME: /opt/data
   HERMES_UID: ${HERMES_UID:-1000}
   HERMES_GID: ${HERMES_GID:-1000}
+  SEARXNG_URL: http://searxng:8080
 
 x-hermes-common: &hermes-common
   image: ${HERMES_IMAGE:-nousresearch/hermes-agent:latest}
@@ -33,6 +34,7 @@ services:
       - "${HERMES_MAIN_GATEWAY_BIND:-127.0.0.1}:${HERMES_MAIN_GATEWAY_PORT:-8642}:8642"
     depends_on:
       - openviking
+      - searxng
 
   hermes-owashota:
     <<: *hermes-common
@@ -54,6 +56,7 @@ services:
       - "${HERMES_OWASHOTA_GATEWAY_BIND:-127.0.0.1}:${HERMES_OWASHOTA_GATEWAY_PORT:-8643}:8642"
     depends_on:
       - openviking
+      - searxng
 
   openviking:
     image: ${OPENVIKING_IMAGE:-ghcr.io/volcengine/openviking:latest}
@@ -71,6 +74,47 @@ services:
       - "${OPENVIKING_BIND:-127.0.0.1}:${OPENVIKING_PORT:-1933}:1933"
     networks:
       - hermes-net
+
+  searxng:
+    image: ${SEARXNG_IMAGE:-docker.io/searxng/searxng:latest}
+    container_name: backup-secretary-searxng
+    restart: unless-stopped
+    environment:
+      SEARXNG_BASE_URL: ${SEARXNG_BASE_URL:-http://searxng:8080/}
+      SEARXNG_VALKEY_URL: valkey://valkey:6379/0
+    volumes:
+      - type: bind
+        source: ${SEARXNG_CONFIG_DIR:-./config/searxng}
+        target: /etc/searxng
+        read_only: true
+    ports:
+      - "${SEARXNG_BIND:-127.0.0.1}:${SEARXNG_PORT:-8080}:8080"
+    networks:
+      - hermes-net
+    depends_on:
+      valkey:
+        condition: service_healthy
+    mem_limit: ${SEARXNG_MEMORY_LIMIT:-512m}
+    cpus: ${SEARXNG_CPU_LIMIT:-0.5}
+
+  valkey:
+    image: ${VALKEY_IMAGE:-docker.io/valkey/valkey:8-alpine}
+    container_name: backup-secretary-valkey
+    restart: unless-stopped
+    command: valkey-server --save 30 1 --loglevel warning
+    volumes:
+      - type: volume
+        source: searxng-valkey-data
+        target: /data
+    networks:
+      - hermes-net
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+    mem_limit: ${VALKEY_MEMORY_LIMIT:-128m}
+    cpus: ${VALKEY_CPU_LIMIT:-0.25}
 
   setup-main:
     <<: *hermes-common
@@ -119,3 +163,6 @@ services:
 networks:
   hermes-net:
     driver: bridge
+
+volumes:
+  searxng-valkey-data:

--- a/config/searxng/README.md
+++ b/config/searxng/README.md
@@ -1,0 +1,40 @@
+# SearXNG configuration
+
+This directory is mounted read-only at `/etc/searxng`.
+
+## Purpose
+
+- Hermes uses `http://searxng:8080` through the shared Docker network.
+- JSON output is enabled because the Hermes SearXNG provider uses the JSON API.
+- Valkey stores limiter state and other short-lived shared data.
+- The host port is bound to `127.0.0.1` by default and is intended only for diagnostics.
+
+## Start and verify
+
+```bash
+docker compose up -d valkey searxng
+curl -fsS "http://127.0.0.1:8080/search?q=OpenViking&format=json"
+```
+
+A successful response contains a JSON object with a `results` array.
+
+## Security
+
+No fixed `server.secret_key` is committed to the repository. Keep `SEARXNG_BIND=127.0.0.1` unless access is protected by a VPN or reverse proxy. If SearXNG is exposed outside the host, configure a deployment-specific secret through an untracked local settings override or another secret-management mechanism.
+
+## Hermes configuration
+
+Each Hermes instance has:
+
+```yaml
+web:
+  search_backend: searxng
+```
+
+The Compose common environment supplies:
+
+```text
+SEARXNG_URL=http://searxng:8080
+```
+
+SearXNG provides web search only. Page extraction remains unset and can be added separately later.

--- a/config/searxng/settings.yml
+++ b/config/searxng/settings.yml
@@ -1,0 +1,13 @@
+use_default_settings: true
+
+server:
+  limiter: true
+  image_proxy: true
+
+search:
+  formats:
+    - html
+    - json
+
+valkey:
+  url: valkey://valkey:6379/0

--- a/runtime/main/hermes-data/config.yaml
+++ b/runtime/main/hermes-data/config.yaml
@@ -29,6 +29,8 @@ tool_output:
   max_line_length: 2000
 display:
   tool_progress: all
+web:
+  search_backend: searxng
 plugins:
   enabled: []
 _config_version: 33
@@ -62,7 +64,7 @@ _config_version: 33
 #   kimi-coding  (KIMI_API_KEY)        — Kimi / Moonshot
 #   kimi-coding-cn (KIMI_CN_API_KEY)   — Kimi / Moonshot (China)
 #   minimax      (MINIMAX_API_KEY)     — MiniMax
-#   minimax-cn   (MINIMAX_CN_API_KEY)  — MiniMax (China)
+#   minimax-cn   (MINIMAX_API_KEY)     — MiniMax
 #   bedrock      (AWS IAM / boto3)     — AWS Bedrock (Converse API)
 #
 # For custom OpenAI-compatible endpoints, add base_url and key_env.

--- a/runtime/owashota/hermes-data/config.yaml
+++ b/runtime/owashota/hermes-data/config.yaml
@@ -29,6 +29,8 @@ tool_output:
   max_line_length: 2000
 display:
   tool_progress: all
+web:
+  search_backend: searxng
 plugins:
   enabled: []
 _config_version: 33


### PR DESCRIPTION
## Summary

Add a shared self-hosted web search stack to the `rework/runtime-openviking` runtime layout.

- add SearXNG and Valkey services to Compose
- share one SearXNG instance between `hermes-main` and `hermes-owashota`
- configure Hermes to use the native `searxng` search backend
- enable SearXNG JSON responses required by Hermes
- connect SearXNG limiter state to Valkey
- keep the diagnostic SearXNG port bound to localhost by default
- document startup, verification, and secret-key replacement
- add configurable images, ports, paths, and resource limits to `.env.example`

## Architecture

```text
hermes-main -----\
                  >--- searxng --- valkey
hermes-owashota -/
```

OpenViking and Hermes instance separation remain unchanged.

## Verification

```bash
docker compose config
docker compose up -d valkey searxng
curl -fsS "http://127.0.0.1:8080/search?q=OpenViking&format=json"
```

The curl response should be a JSON object containing a `results` array.

## Notes

- This adds search only; no `extract_backend` is configured.
- `config/searxng/settings.yml` includes a repository-local secret for private localhost-only use. The README documents replacing it before exposing SearXNG externally.
