### PR TITLE
config: use GPT-5.6 Sol for main Hermes model

### DIFF
--- a/runtime/main/hermes-data/config.yaml
+++ b/runtime/main/hermes-data/config.yaml
@@ -1,8 +1,6 @@
 model:
-  provider: opencode-go
-  base_url: https://opencode.ai/zen/go/v1
-  api_mode: chat_completions
-  default: deepseek-v4-flash
+  provider: openai-codex
+  default: gpt-5.6-sol
 toolsets:
   - hermes-cli
 agent:
@@ -11,6 +9,31 @@ agent:
   api_max_retries: 3
   reasoning_effort: medium
   verify_on_stop: false
+auxiliary:
+  web_extract:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  compression:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  session_search:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  skills_hub:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  approval:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  mcp:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  title_generation:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  curator:
+    provider: opencode-go
+    model: deepseek-v4-flash
 session_reset:
   mode: idle
   idle_minutes: 1440


### PR DESCRIPTION
## Summary
- switch the main Hermes model from `deepseek-v4-flash` via `opencode-go` to `gpt-5.6-sol` via `openai-codex`
- keep main-agent reasoning effort at `medium`
- route every configured non-vision auxiliary slot to `deepseek-v4-flash` via `opencode-go`
- leave vision unconfigured/unchanged so it is not routed to V4 Flash

## Auxiliary slots
- `web_extract`
- `compression`
- `session_search`
- `skills_hub`
- `approval`
- `mcp`
- `title_generation`
- `curator`

## Validation
- reviewed the resulting YAML on the feature branch
- confirmed the PR is based on `rework/runtime-openviking`

## Notes
- requires Hermes `openai-codex` authentication for the main model
- uses the existing `deepseek-v4-flash` model ID already present elsewhere in the repository