### PR TITLE
Configure GPT-5.6 Sol with V4 Flash auxiliaries

### DIFF
--- a/config/hermes-config.poc.yaml
+++ b/config/hermes-config.poc.yaml
@@ -1,6 +1,40 @@
 # Non-secret Hermes settings for the backup-secretary PoC.
 # Copy selected values into runtime/hermes-data/config.yaml after `docker compose --profile setup run --rm setup`.
 
+model:
+  model: gpt-5.6-sol
+  default: gpt-5.6-sol
+  provider: openai-codex
+
+agent:
+  reasoning_effort: medium
+
+auxiliary:
+  web_extract:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  compression:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  session_search:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  skills_hub:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  approval:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  mcp:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  title_generation:
+    provider: opencode-go
+    model: deepseek-v4-flash
+  curator:
+    provider: opencode-go
+    model: deepseek-v4-flash
+
 terminal:
   # Hermes itself already runs inside the hardened Compose container.
   # Do not mount /var/run/docker.sock for this PoC; it would grant host-level Docker control.
@@ -52,4 +86,3 @@ security:
 #       - "--from"
 #       - "mcp-crawl4ai"
 #       - "crawl4ai-mcp"
-


### PR DESCRIPTION
## Changes
- Set the Hermes main model template to `gpt-5.6-sol` via `openai-codex`
- Set main reasoning effort to `medium`
- Route all configured auxiliary slots except `vision` to `deepseek-v4-flash` via `opencode-go`
- Leave `vision` unspecified so the existing active vision configuration is preserved

## Auxiliary slots covered
- `web_extract`
- `compression`
- `session_search`
- `skills_hub`
- `approval`
- `mcp`
- `title_generation`
- `curator`

## Notes
`config/hermes-config.poc.yaml` is the repository-managed non-secret configuration template. The active Hermes data directory is mounted externally by Compose, so these values need to be merged into the deployed `/opt/data/config.yaml` as part of the existing setup flow.

## Validation
- YAML structure reviewed against the auxiliary slots currently present in `runtime/hermes-data/config.yaml`
- `vision` was intentionally not added or changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the default model selection to GPT-5.6-Sol through the OpenAI Codex provider.
  * Set agent reasoning effort to medium.
  * Configured auxiliary capabilities to use DeepSeek V4 Flash through the OpenCode provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->