### PR TITLE
Fix Hermes delegated-session user attribution

### DIFF
--- a/docker/hermes/Dockerfile
+++ b/docker/hermes/Dockerfile
@@ -9,6 +9,7 @@ ARG OTEL_PYTHON_VERSION=1.44.0
 ARG PYYAML_VERSION=6.0.3
 
 COPY hermes-otel-privacy.patch /tmp/hermes-otel-privacy.patch
+COPY hermes-otel-subagent-user.patch /tmp/hermes-otel-subagent-user.patch
 
 RUN set -eux; \
   apt-get update; \
@@ -42,10 +43,12 @@ RUN set -eux; \
   test "$(git -C /opt/hermes/plugins/hermes_otel rev-parse HEAD)" = "${HERMES_OTEL_REF}"; \
   git -C /opt/hermes/plugins/hermes_otel apply --check /tmp/hermes-otel-privacy.patch; \
   git -C /opt/hermes/plugins/hermes_otel apply /tmp/hermes-otel-privacy.patch; \
+  git -C /opt/hermes/plugins/hermes_otel apply --check /tmp/hermes-otel-subagent-user.patch; \
+  git -C /opt/hermes/plugins/hermes_otel apply /tmp/hermes-otel-subagent-user.patch; \
   ! grep -Eq '"hermes\.(tool\.(command|target)|turn\.tool_(commands|targets))"' /opt/hermes/plugins/hermes_otel/hooks.py; \
   ! grep -Fq '"error.message"' /opt/hermes/plugins/hermes_otel/hooks.py; \
   rm -rf /opt/hermes/plugins/hermes_otel/.git; \
-  rm -f /tmp/hermes-otel-privacy.patch; \
+  rm -f /tmp/hermes-otel-privacy.patch /tmp/hermes-otel-subagent-user.patch; \
   if [ "$HERMES_GID" != "$(id -g hermes)" ]; then \
   groupmod -o -g "$HERMES_GID" hermes; \
   fi; \

--- a/docker/hermes/hermes-otel-subagent-user.patch
+++ b/docker/hermes/hermes-otel-subagent-user.patch
@@ -1,0 +1,35 @@
+diff --git a/hooks.py b/hooks.py
+index b8ea701..43ac761 100644
+--- a/hooks.py
++++ b/hooks.py
+@@ -604,6 +604,12 @@ def _start_session_span(
+     record = tracer._subagent_registry.get(session_id)
+     if record:
+         attributes["hermes.session.is_subagent"] = True
++        sender_attributes = record.get("sender_attributes") or {}
++        attributes.update(sender_attributes)
++        if sender_attributes and session_id:
++            ps = tracer.sessions.get_or_create(session_id)
++            ps.sender_id = sender_attributes.get("hermes.sender.id", "")
++            ps.user_id = sender_attributes.get("user.id", "")
+         if record.get("role"):
+             attributes["hermes.subagent.role"] = truncate_string(record["role"], 200)
+         if record.get("parent_session_id"):
+@@ -1638,6 +1644,8 @@ def on_subagent_start(
+         attributes["hermes.subagent.goal"] = goal_preview
+         attributes["input.value"] = goal_preview
+     attributes.update(_correlation_attributes(tracer, parent_session_id, kwargs))
++    sender_attributes = _session_sender_attributes(tracer, parent_session_id)
++    attributes.update(sender_attributes)
+-
++
+     # Nest under the parent session's in-flight span (api/llm/session). The
+     # delegation span is NOT pushed as a parent — the parent session keeps
+@@ -1655,6 +1663,7 @@ def on_subagent_start(
+         "span": span,
+         "role": role,
+         "parent_session_id": parent_session_id,
++        "sender_attributes": sender_attributes,
+     }
+     if span is not None and hasattr(span, "get_span_context"):
+         try:

--- a/docker/hermes/hermes-otel-subagent-user.patch
+++ b/docker/hermes/hermes-otel-subagent-user.patch
@@ -1,5 +1,5 @@
 diff --git a/hooks.py b/hooks.py
-index b8ea701..43ac761 100644
+index b8ea701..3a65677 100644
 --- a/hooks.py
 +++ b/hooks.py
 @@ -604,6 +604,12 @@ def _start_session_span(
@@ -15,7 +15,28 @@ index b8ea701..43ac761 100644
          if record.get("role"):
              attributes["hermes.subagent.role"] = truncate_string(record["role"], 200)
          if record.get("parent_session_id"):
-@@ -1638,6 +1644,8 @@ def on_subagent_start(
+@@ -1105,5 +1111,10 @@ def on_pre_llm_call(
+     if tracer.config.capture_sender_id:
+-        sender_id = truncate_string(kwargs.get("sender_id"), 200)
++        raw_sender_id = kwargs.get("sender_id")
++        sender_id = (
++            truncate_string(raw_sender_id, 200)
++            if raw_sender_id is not None and str(raw_sender_id).strip()
++            else None
++        )
+         if sender_id:
+             sender_platform = truncate_string(platform, 120)
+             sender_attrs = _sender_attributes(sender_id, sender_platform)
+@@ -1112,6 +1123,7 @@ def on_pre_llm_call(
+                 ps = tracer.sessions.get_or_create(session_id)
+                 ps.sender_id = sender_id
+                 ps.user_id = sender_attrs["user.id"]
++        attributes.update(_session_sender_attributes(tracer, session_id))
+-
++
+     # Opt-in: put the entire conversation the model is about to see on
+     # input.value. Falls back to just the latest user_message otherwise —
+@@ -1638,6 +1650,8 @@ def on_subagent_start(
          attributes["hermes.subagent.goal"] = goal_preview
          attributes["input.value"] = goal_preview
      attributes.update(_correlation_attributes(tracer, parent_session_id, kwargs))
@@ -25,7 +46,7 @@ index b8ea701..43ac761 100644
 +
      # Nest under the parent session's in-flight span (api/llm/session). The
      # delegation span is NOT pushed as a parent — the parent session keeps
-@@ -1655,6 +1663,7 @@ def on_subagent_start(
+@@ -1655,6 +1669,7 @@ def on_subagent_start(
          "span": span,
          "role": role,
          "parent_session_id": parent_session_id,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -19,7 +19,9 @@ The build also applies a focused patch that propagates the already captured
 parent sender identity to delegated child-agent sessions. This keeps
 content-free child `agent` token rollups attributable to the initiating
 Discord user without capturing any additional identity or message fields. The
-image test exercises this behavior with a synthetic sender value.
+image test exercises a sender-less child LLM/API lifecycle with a synthetic
+parent sender and verifies the child `agent`, `llm.*`, and `api.*` spans retain
+that identity and token rollup without content attributes.
 
 The Docker build clones exactly the reviewed plugin commit into Hermes' bundled plugin directory and installs dependencies into `/opt/hermes/.venv`. No running container installs plugin code or Python packages.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -15,6 +15,12 @@ The Compose defaults for the other external service images are digest-pinned as 
 
 The reviewed upstream commit emits `hermes.tool.command`, `hermes.tool.target`, their turn rollups, and raw tool error messages even when previews are disabled. A checked-in build-time privacy patch removes those content-bearing attributes while retaining tool names, outcomes, durations, errors as a fixed category, token counts, models, instance identity, and sender identity. The standalone collector independently deletes the same deny-listed attributes as defense in depth.
 
+The build also applies a focused patch that propagates the already captured
+parent sender identity to delegated child-agent sessions. This keeps
+content-free child `agent` token rollups attributable to the initiating
+Discord user without capturing any additional identity or message fields. The
+image test exercises this behavior with a synthetic sender value.
+
 The Docker build clones exactly the reviewed plugin commit into Hermes' bundled plugin directory and installs dependencies into `/opt/hermes/.venv`. No running container installs plugin code or Python packages.
 
 The pinned Hermes 0.18.2 image already contains the free-response/auto-thread fix in its bundled Discord adapter. The obsolete pre-0.18.2 monkey patch was removed because its former module path no longer exists.

--- a/scripts/test-hermes-otel-image.sh
+++ b/scripts/test-hermes-otel-image.sh
@@ -52,6 +52,97 @@ for name in ("main", "owashota"):
 print("CONFIG_ASSERTIONS_OK")
 PY
 
+python - <<'PY'
+import sys
+
+sys.path.insert(0, "/opt/hermes/plugins")
+
+from hermes_otel.hooks import (
+    on_post_llm_call,
+    on_pre_llm_call,
+    on_session_end,
+    on_session_start,
+    on_subagent_start,
+    on_subagent_stop,
+)
+from hermes_otel.plugin_config import HermesOtelConfig
+from hermes_otel.tracer import HermesOTelPlugin
+import hermes_otel.tracer as tracer_module
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider(resource=Resource.create({"service.name": "synthetic-test"}))
+provider.add_span_processor(SimpleSpanProcessor(exporter))
+plugin = HermesOTelPlugin(config=HermesOtelConfig(capture_sender_id=True))
+plugin.tracer = provider.get_tracer("subagent-sender-test")
+plugin._initialized = True
+tracer_module._tracer = plugin
+
+try:
+    on_session_start(session_id="parent", model="test-model", platform="discord")
+    on_pre_llm_call(
+        session_id="parent",
+        user_message="synthetic",
+        conversation_history=[],
+        is_first_turn=True,
+        model="test-model",
+        platform="discord",
+        sender_id="synthetic-user",
+    )
+    on_subagent_start(
+        parent_session_id="parent",
+        child_session_id="child",
+        child_role="synthetic-role",
+    )
+    on_session_start(session_id="child", model="test-model", platform="subagent")
+    on_session_end(
+        session_id="child",
+        completed=True,
+        interrupted=False,
+        model="test-model",
+        platform="subagent",
+    )
+    on_subagent_stop(
+        parent_session_id="parent",
+        child_session_id="child",
+        child_role="synthetic-role",
+        child_status="completed",
+    )
+    on_post_llm_call(
+        session_id="parent",
+        user_message="synthetic",
+        assistant_response="synthetic",
+        conversation_history=[],
+        model="test-model",
+        platform="discord",
+    )
+    on_session_end(
+        session_id="parent",
+        completed=True,
+        interrupted=False,
+        model="test-model",
+        platform="discord",
+    )
+
+    child_agents = [
+        span
+        for span in exporter.get_finished_spans()
+        if span.name == "agent" and dict(span.attributes).get("hermes.session.is_subagent") is True
+    ]
+    assert len(child_agents) == 1
+    child_attributes = dict(child_agents[0].attributes)
+    assert child_attributes["hermes.sender.id"] == "synthetic-user"
+    assert child_attributes["user.id"] == "discord:synthetic-user"
+    print("SUBAGENT_SENDER_INHERITANCE_OK")
+finally:
+    provider.shutdown()
+    tracer_module._tracer = None
+PY
+
 hermes plugins enable --no-allow-tool-override hermes_otel >/dev/null
 python - <<'PY'
 from hermes_cli.plugins import get_plugin_manager

--- a/scripts/test-hermes-otel-image.sh
+++ b/scripts/test-hermes-otel-image.sh
@@ -58,7 +58,9 @@ import sys
 sys.path.insert(0, "/opt/hermes/plugins")
 
 from hermes_otel.hooks import (
+    on_post_api_request,
     on_post_llm_call,
+    on_pre_api_request,
     on_pre_llm_call,
     on_session_end,
     on_session_start,
@@ -77,7 +79,15 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 exporter = InMemorySpanExporter()
 provider = TracerProvider(resource=Resource.create({"service.name": "synthetic-test"}))
 provider.add_span_processor(SimpleSpanProcessor(exporter))
-plugin = HermesOTelPlugin(config=HermesOtelConfig(capture_sender_id=True))
+plugin = HermesOTelPlugin(
+    config=HermesOtelConfig(
+        capture_sender_id=True,
+        capture_previews=False,
+        capture_conversation_history=False,
+        capture_full_prompts=False,
+        capture_full_responses=False,
+    )
+)
 plugin.tracer = provider.get_tracer("subagent-sender-test")
 plugin._initialized = True
 tracer_module._tracer = plugin
@@ -99,6 +109,60 @@ try:
         child_role="synthetic-role",
     )
     on_session_start(session_id="child", model="test-model", platform="subagent")
+    on_pre_llm_call(
+        session_id="child",
+        user_message="synthetic child input",
+        conversation_history=[],
+        is_first_turn=True,
+        model="test-model",
+        platform="subagent",
+    )
+    on_pre_api_request(
+        task_id="child-task",
+        session_id="child",
+        platform="subagent",
+        model="test-model",
+        provider="synthetic-provider",
+        base_url="https://invalid.example",
+        api_mode="chat",
+        api_call_count=1,
+        message_count=1,
+        tool_count=0,
+        approx_input_tokens=11,
+        request_char_count=21,
+        max_tokens=100,
+    )
+    on_post_api_request(
+        task_id="child-task",
+        session_id="child",
+        platform="subagent",
+        model="test-model",
+        provider="synthetic-provider",
+        base_url="https://invalid.example",
+        api_mode="chat",
+        api_call_count=1,
+        api_duration=0.01,
+        finish_reason="stop",
+        message_count=1,
+        response_model="test-model",
+        usage={
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "total_tokens": 18,
+            "cache_read_tokens": 3,
+            "reasoning_tokens": 2,
+        },
+        assistant_content_chars=22,
+        assistant_tool_call_count=0,
+    )
+    on_post_llm_call(
+        session_id="child",
+        user_message="synthetic child input",
+        assistant_response="synthetic child output",
+        conversation_history=[],
+        model="test-model",
+        platform="subagent",
+    )
     on_session_end(
         session_id="child",
         completed=True,
@@ -128,15 +192,45 @@ try:
         platform="discord",
     )
 
-    child_agents = [
+    finished_spans = exporter.get_finished_spans()
+    child_spans = [
         span
-        for span in exporter.get_finished_spans()
-        if span.name == "agent" and dict(span.attributes).get("hermes.session.is_subagent") is True
+        for span in finished_spans
+        if dict(span.attributes).get("session.id") == "child"
     ]
-    assert len(child_agents) == 1
-    child_attributes = dict(child_agents[0].attributes)
-    assert child_attributes["hermes.sender.id"] == "synthetic-user"
-    assert child_attributes["user.id"] == "discord:synthetic-user"
+    assert {span.name for span in child_spans} == {
+        "agent",
+        "api.test-model",
+        "llm.test-model",
+    }
+    for span in child_spans:
+        attributes = dict(span.attributes)
+        assert attributes["hermes.sender.id"] == "synthetic-user"
+        assert attributes["user.id"] == "discord:synthetic-user"
+        assert attributes.get("hermes.sender.id") != "None"
+        assert attributes.get("user.id") != "subagent:None"
+        for blocked_key in (
+            "input.value",
+            "output.value",
+            "gen_ai.input.messages",
+            "gen_ai.output.messages",
+            "llm.input_messages",
+            "llm.output.content",
+        ):
+            assert blocked_key not in attributes
+
+    child_agent = next(span for span in child_spans if span.name == "agent")
+    child_attributes = dict(child_agent.attributes)
+    assert child_attributes["gen_ai.usage.input_tokens"] == 11
+    assert child_attributes["gen_ai.usage.output_tokens"] == 7
+    assert child_attributes["gen_ai.usage.total_tokens"] == 18
+    assert child_attributes["gen_ai.usage.cache_read.input_tokens"] == 3
+    assert child_attributes["gen_ai.usage.reasoning.output_tokens"] == 2
+
+    delegation = next(span for span in finished_spans if span.name == "subagent.synthetic-role")
+    delegation_attributes = dict(delegation.attributes)
+    assert delegation_attributes["hermes.sender.id"] == "synthetic-user"
+    assert delegation_attributes["user.id"] == "discord:synthetic-user"
     print("SUBAGENT_SENDER_INHERITANCE_OK")
 finally:
     provider.shutdown()


### PR DESCRIPTION
## What changed

- carry the parent Discord sender identity through delegated child session state
- retain the initiating `user.id` on child agent, LLM, and API spans
- prevent a missing child sender from overwriting inherited identity with `None`
- extend the image regression test for the complete sender-less child lifecycle and token rollup

## Why

The original Phase 1 plugin integration did not propagate parent sender identity into delegated child sessions. That made child usage unattributed or incorrectly attributed even though the parent Discord turn was known.

## Validation

- both commits were cleanly replayed onto the merged Phase 1 `main`
- `git diff --check`, Compose rendering, and shell syntax pass in a separate clean server worktree
- the deployed reviewed image passes configuration, privacy, sender inheritance, plugin load, and plugin-enable assertions
- prior synthetic and owner-run real Discord verification confirmed consistent parent/child attribution, root token rollup, zero nil/`None` users, and no blocked content attributes

## Safety

- no real Discord ID, trace ID, credential, private endpoint, or runtime data is committed
- the dirty live runtime checkout is not modified by this PR