### PR TITLE
Persist Phase 1 observability in the active runtime topology

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,12 @@
 # コンテナの image / mount path / port / env_file の場所だけを書く。
 # Discord token、LLM API key、OpenViking API key などの秘密情報は置かない。
 
-# Hermes公式image
-HERMES_IMAGE=nousresearch/hermes-agent:latest
+# Phase 1 privacy/attribution patches are built into this local image.
+HERMES_IMAGE=backup-secretary/hermes-agent:local
+HERMES_BASE_IMAGE=nousresearch/hermes-agent@sha256:00f57d79b2b20745a4f2c47bd26135f0473100ca23103ffc3eb3f89f3f6cef50
+HERMES_OTEL_REF=0180c5e63b9d035ee0754d9a0d75c3499a8def26
+OTEL_PYTHON_VERSION=1.44.0
+PYYAML_VERSION=6.0.3
 
 # Hermesコンテナをホストユーザーと同じUID/GIDで実行する。
 # Linux / WSL: id -u / id -g の結果を設定する。

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.sh text eol=lf
+*.yaml text eol=lf
+*.md text eol=lf

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,13 +5,54 @@ x-hermes-environment: &hermes-environment
   HOME: /opt/data
   HERMES_UID: ${HERMES_UID:-1000}
   HERMES_GID: ${HERMES_GID:-1000}
+  HERMES_EXEC_ASK: "1"
   SEARXNG_URL: http://searxng:8080
 
+x-hermes-otel-env: &hermes-otel-env
+  HERMES_OTEL_ENABLED: "true"
+  HERMES_OTEL_CAPTURE_PREVIEWS: "false"
+  HERMES_OTEL_CAPTURE_CONVERSATION_HISTORY: "false"
+  HERMES_OTEL_CAPTURE_FULL_PROMPTS: "false"
+  HERMES_OTEL_CAPTURE_FULL_RESPONSES: "false"
+  HERMES_OTEL_CAPTURE_SENDER_ID: "true"
+  HERMES_OTEL_CAPTURE_LOGS: "false"
+  HERMES_OTEL_DASHBOARD_LIVE: "false"
+  HERMES_OTEL_FORCE_FLUSH_ON_SESSION_END: "false"
+  HERMES_OTEL_SPAN_BATCH_EXPORT_TIMEOUT_MS: "3000"
+  HERMES_OTEL_DEBUG: "false"
+
 x-hermes-common: &hermes-common
-  image: ${HERMES_IMAGE:-nousresearch/hermes-agent:latest}
+  image: ${HERMES_IMAGE:-backup-secretary/hermes-agent:local}
+  build:
+    context: ./docker/hermes
+    dockerfile: Dockerfile
+    args:
+      HERMES_BASE_IMAGE: ${HERMES_BASE_IMAGE:-nousresearch/hermes-agent@sha256:00f57d79b2b20745a4f2c47bd26135f0473100ca23103ffc3eb3f89f3f6cef50}
+      HERMES_UID: ${HERMES_UID:-1000}
+      HERMES_GID: ${HERMES_GID:-1000}
+      HERMES_OTEL_REF: ${HERMES_OTEL_REF:-0180c5e63b9d035ee0754d9a0d75c3499a8def26}
+      OTEL_PYTHON_VERSION: ${OTEL_PYTHON_VERSION:-1.44.0}
+      PYYAML_VERSION: ${PYYAML_VERSION:-6.0.3}
   restart: unless-stopped
   networks:
     - hermes-net
+  read_only: ${HERMES_READ_ONLY:-false}
+  tmpfs:
+    - /tmp:rw,nosuid,size=512m
+    - /var/tmp:rw,noexec,nosuid,size=256m
+    - /run:rw,noexec,nosuid,size=64m
+  cap_drop:
+    - ALL
+  cap_add:
+    - CHOWN
+    - SETGID
+    - SETUID
+  security_opt:
+    - no-new-privileges:true
+  pids_limit: 256
+  mem_limit: ${HERMES_MEMORY_LIMIT:-4g}
+  cpus: ${HERMES_CPU_LIMIT:-2}
+  shm_size: ${HERMES_SHM_SIZE:-1g}
 
 services:
   hermes-main:
@@ -21,7 +62,7 @@ services:
     env_file:
       - ${HERMES_MAIN_ENV_FILE:-./runtime/main/hermes-data/.env}
     environment:
-      <<: *hermes-environment
+      <<: [*hermes-environment, *hermes-otel-env]
       OPENVIKING_ENDPOINT: http://openviking:1933
     volumes:
       - type: bind
@@ -30,8 +71,23 @@ services:
       - type: bind
         source: ${HERMES_WORKSPACE_DIR:-./workspace}
         target: /workspace
+      - type: bind
+        source: ./observability/hermes-otel/main.yaml
+        target: /opt/data/.hermes/plugins/hermes_otel/config.yaml
+        read_only: true
+    networks:
+      - hermes-net
+      - local-observability-net
     ports:
       - "${HERMES_MAIN_GATEWAY_BIND:-127.0.0.1}:${HERMES_MAIN_GATEWAY_PORT:-8642}:8642"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "pgrep -f 'hermes gateway run' >/dev/null"
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     depends_on:
       - openviking
       - searxng
@@ -43,7 +99,7 @@ services:
     env_file:
       - ${HERMES_OWASHOTA_ENV_FILE:-./runtime/owashota/hermes-data/.env}
     environment:
-      <<: *hermes-environment
+      <<: [*hermes-environment, *hermes-otel-env]
       OPENVIKING_ENDPOINT: http://openviking:1933
     volumes:
       - type: bind
@@ -52,11 +108,29 @@ services:
       - type: bind
         source: ${HERMES_WORKSPACE_DIR:-./workspace}
         target: /workspace
+      - type: bind
+        source: ./observability/hermes-otel/owashota.yaml
+        target: /opt/data/.hermes/plugins/hermes_otel/config.yaml
+        read_only: true
+    networks:
+      - hermes-net
+      - local-observability-net
     ports:
       - "${HERMES_OWASHOTA_GATEWAY_BIND:-127.0.0.1}:${HERMES_OWASHOTA_GATEWAY_PORT:-8643}:8642"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - "pgrep -f 'hermes gateway run' >/dev/null"
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     depends_on:
       - openviking
       - searxng
+    mem_limit: ${HERMES_OWASHOTA_MEMORY_LIMIT:-2g}
+    cpus: ${HERMES_OWASHOTA_CPU_LIMIT:-1}
+    shm_size: ${HERMES_OWASHOTA_SHM_SIZE:-512m}
 
   openviking:
     image: ${OPENVIKING_IMAGE:-ghcr.io/volcengine/openviking:latest}
@@ -163,6 +237,9 @@ services:
 networks:
   hermes-net:
     driver: bridge
+  local-observability-net:
+    external: true
+    name: local-observability-net
 
 volumes:
   searxng-valkey-data:

--- a/docker/hermes/Dockerfile
+++ b/docker/hermes/Dockerfile
@@ -1,0 +1,59 @@
+ARG HERMES_BASE_IMAGE=nousresearch/hermes-agent@sha256:00f57d79b2b20745a4f2c47bd26135f0473100ca23103ffc3eb3f89f3f6cef50
+
+FROM ${HERMES_BASE_IMAGE}
+
+ARG HERMES_UID=1000
+ARG HERMES_GID=1000
+ARG HERMES_OTEL_REF=0180c5e63b9d035ee0754d9a0d75c3499a8def26
+ARG OTEL_PYTHON_VERSION=1.44.0
+ARG PYYAML_VERSION=6.0.3
+
+COPY hermes-otel-privacy.patch /tmp/hermes-otel-privacy.patch
+
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends gh git rsync; \
+  rm -rf /var/lib/apt/lists/*; \
+  npm install -g @openai/codex; \
+  npm install -g @anthropic-ai/claude-code; \
+  npm cache clean --force; \
+  # Install Scrapling for web extraction fallback (stealthy_fetch / fetch for JS-required & bot-protected sites)
+  . /opt/hermes/.venv/bin/activate && uv pip install --no-cache-dir "scrapling[ai]"; \
+  # Install messaging platform deps (discord, telegram, slack) at build time
+  # because lazy_deps.py fails after usermod changes the hermes user's UID,
+  # making the venv site-packages unwritable at runtime.
+  . /opt/hermes/.venv/bin/activate && uv pip install --no-cache-dir \
+    "discord.py[voice]==2.7.1" \
+    "brotlicffi==1.2.0.1" \
+    "python-telegram-bot[webhooks]==22.6" \
+    "aiohttp==3.13.3" \
+    "slack-bolt==1.27.0" \
+    "slack-sdk==3.40.1"; \
+  # Install the reviewed hermes-otel source and OTel dependencies at image
+  # build time. Runtime containers never install or mutate plugin code.
+  . /opt/hermes/.venv/bin/activate && uv pip install --no-cache-dir \
+    "opentelemetry-api==${OTEL_PYTHON_VERSION}" \
+    "opentelemetry-sdk==${OTEL_PYTHON_VERSION}" \
+    "opentelemetry-exporter-otlp-proto-http==${OTEL_PYTHON_VERSION}" \
+    "PyYAML==${PYYAML_VERSION}"; \
+  git clone --filter=blob:none https://github.com/briancaffey/hermes-otel.git \
+    /opt/hermes/plugins/hermes_otel; \
+  git -C /opt/hermes/plugins/hermes_otel checkout --detach "${HERMES_OTEL_REF}"; \
+  test "$(git -C /opt/hermes/plugins/hermes_otel rev-parse HEAD)" = "${HERMES_OTEL_REF}"; \
+  git -C /opt/hermes/plugins/hermes_otel apply --check /tmp/hermes-otel-privacy.patch; \
+  git -C /opt/hermes/plugins/hermes_otel apply /tmp/hermes-otel-privacy.patch; \
+  ! grep -Eq '"hermes\.(tool\.(command|target)|turn\.tool_(commands|targets))"' /opt/hermes/plugins/hermes_otel/hooks.py; \
+  ! grep -Fq '"error.message"' /opt/hermes/plugins/hermes_otel/hooks.py; \
+  rm -rf /opt/hermes/plugins/hermes_otel/.git; \
+  rm -f /tmp/hermes-otel-privacy.patch; \
+  if [ "$HERMES_GID" != "$(id -g hermes)" ]; then \
+  groupmod -o -g "$HERMES_GID" hermes; \
+  fi; \
+  if [ "$HERMES_UID" != "$(id -u hermes)" ]; then \
+  usermod -u "$HERMES_UID" hermes; \
+  fi; \
+  # Re-chown the venv after usermod so the hermes user can write to it
+  # (needed for lazy_deps.py installs at runtime).
+  chown -R hermes:hermes /opt/hermes/.venv; \
+  mkdir -p /opt/data; \
+  chown -R hermes:hermes /opt/data

--- a/docker/hermes/Dockerfile
+++ b/docker/hermes/Dockerfile
@@ -9,6 +9,7 @@ ARG OTEL_PYTHON_VERSION=1.44.0
 ARG PYYAML_VERSION=6.0.3
 
 COPY hermes-otel-privacy.patch /tmp/hermes-otel-privacy.patch
+COPY hermes-otel-subagent-user.patch /tmp/hermes-otel-subagent-user.patch
 
 RUN set -eux; \
   apt-get update; \
@@ -42,10 +43,12 @@ RUN set -eux; \
   test "$(git -C /opt/hermes/plugins/hermes_otel rev-parse HEAD)" = "${HERMES_OTEL_REF}"; \
   git -C /opt/hermes/plugins/hermes_otel apply --check /tmp/hermes-otel-privacy.patch; \
   git -C /opt/hermes/plugins/hermes_otel apply /tmp/hermes-otel-privacy.patch; \
+  git -C /opt/hermes/plugins/hermes_otel apply --check /tmp/hermes-otel-subagent-user.patch; \
+  git -C /opt/hermes/plugins/hermes_otel apply /tmp/hermes-otel-subagent-user.patch; \
   ! grep -Eq '"hermes\.(tool\.(command|target)|turn\.tool_(commands|targets))"' /opt/hermes/plugins/hermes_otel/hooks.py; \
   ! grep -Fq '"error.message"' /opt/hermes/plugins/hermes_otel/hooks.py; \
   rm -rf /opt/hermes/plugins/hermes_otel/.git; \
-  rm -f /tmp/hermes-otel-privacy.patch; \
+  rm -f /tmp/hermes-otel-privacy.patch /tmp/hermes-otel-subagent-user.patch; \
   if [ "$HERMES_GID" != "$(id -g hermes)" ]; then \
   groupmod -o -g "$HERMES_GID" hermes; \
   fi; \

--- a/docker/hermes/hermes-otel-privacy.patch
+++ b/docker/hermes/hermes-otel-privacy.patch
@@ -1,0 +1,73 @@
+diff --git a/hooks.py b/hooks.py
+--- a/hooks.py
++++ b/hooks.py
+@@ -24,7 +24,6 @@ from .helpers import (
+     detect_skill,
+     extract_tool_result_status,
+     http_status_class,
+-    resolve_tool_identity,
+     session_id_from_turn_id,
+     subagent_span_key,
+     subagent_status_to_span_status,
+@@ -91,10 +90,6 @@ def _summary_attributes(summary: TurnSummary) -> Dict[str, Any]:
+     if summary.tool_names:
+         attrs["hermes.turn.tool_count"] = len(summary.tool_names)
+         attrs["hermes.turn.tools"] = _clip_joined(sorted(summary.tool_names), ",")
+-    if summary.tool_targets:
+-        attrs["hermes.turn.tool_targets"] = _clip_joined(summary.tool_targets, "|")
+-    if summary.tool_commands:
+-        attrs["hermes.turn.tool_commands"] = _clip_joined(summary.tool_commands, "|")
+     if summary.tool_outcomes:
+         attrs["hermes.turn.tool_outcomes"] = _clip_joined(sorted(summary.tool_outcomes), ",")
+     if summary.skill_names:
+@@ -822,12 +817,6 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
+         if serialized_args is not None:
+             attributes["gen_ai.tool.call.arguments"] = serialized_args
+-
++
+-    # Richer identity — hermes.tool.* (opt-in namespace)
+-    target, command = resolve_tool_identity(args)
+-    if target:
+-        attributes["hermes.tool.target"] = truncate_string(target, 500)
+-    if command:
+-        attributes["hermes.tool.command"] = truncate_string(command, 500)
+     skill, skill_source = detect_skill(tool_name, args)
+     if skill:
+         attributes["hermes.skill.name"] = skill
+@@ -847,8 +836,6 @@ def on_pre_tool_call(tool_name: str, args: dict, task_id: str, **kwargs):
+         attributes.update(_session_sender_attributes(tracer, session_id))
+         summary = tracer.sessions.get_or_create(session_id).turn_summary
+         summary.add_tool(tool_name)
+-        summary.add_target(target)
+-        summary.add_command(command)
+         summary.add_skill(skill)
+         if skill and tracer.config.skill_spans:
+             _open_skill_span(tracer, session_id, skill, skill_source, kwargs)
+@@ -902,14 +889,9 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
+     outcome = extract_tool_result_status(result_json) or "completed"
+     attributes["hermes.tool.outcome"] = outcome
+-
++
+-    # Preserve existing error.message attribute when outcome == error
+     has_error = outcome == "error"
+-    error_msg = ""
+-    if has_error and isinstance(result_json, dict):
+-        err_val = result_json.get("error")
+-        if err_val:
+-            error_msg = truncate_string(err_val, 500)
+-            attributes["error.message"] = error_msg
++    if has_error:
++        attributes["error.type"] = "tool_error"
+-
++
+     # OpenInference output value — Phoenix shows this in Info
+     preview = _preview(
+@@ -939,7 +921,5 @@ def on_post_tool_call(tool_name: str, args: dict, result: str, task_id: str, **k
+     # Map outcome to span status. Only "error" is ERROR; other non-ok outcomes
+     # (timeout, blocked, ...) are OK to avoid polluting error rates.
+     status = "error" if has_error else "ok"
+-    tracer.end_span(
+-        key, attributes=attributes, status=status, error_message=error_msg if has_error else None
+-    )
++    tracer.end_span(key, attributes=attributes, status=status)
+     debug_log(f"  span ended: status={status}, outcome={outcome}")

--- a/docker/hermes/hermes-otel-subagent-user.patch
+++ b/docker/hermes/hermes-otel-subagent-user.patch
@@ -1,0 +1,56 @@
+diff --git a/hooks.py b/hooks.py
+index b8ea701..3a65677 100644
+--- a/hooks.py
++++ b/hooks.py
+@@ -604,6 +604,12 @@ def _start_session_span(
+     record = tracer._subagent_registry.get(session_id)
+     if record:
+         attributes["hermes.session.is_subagent"] = True
++        sender_attributes = record.get("sender_attributes") or {}
++        attributes.update(sender_attributes)
++        if sender_attributes and session_id:
++            ps = tracer.sessions.get_or_create(session_id)
++            ps.sender_id = sender_attributes.get("hermes.sender.id", "")
++            ps.user_id = sender_attributes.get("user.id", "")
+         if record.get("role"):
+             attributes["hermes.subagent.role"] = truncate_string(record["role"], 200)
+         if record.get("parent_session_id"):
+@@ -1105,5 +1111,10 @@ def on_pre_llm_call(
+     if tracer.config.capture_sender_id:
+-        sender_id = truncate_string(kwargs.get("sender_id"), 200)
++        raw_sender_id = kwargs.get("sender_id")
++        sender_id = (
++            truncate_string(raw_sender_id, 200)
++            if raw_sender_id is not None and str(raw_sender_id).strip()
++            else None
++        )
+         if sender_id:
+             sender_platform = truncate_string(platform, 120)
+             sender_attrs = _sender_attributes(sender_id, sender_platform)
+@@ -1112,6 +1123,7 @@ def on_pre_llm_call(
+                 ps = tracer.sessions.get_or_create(session_id)
+                 ps.sender_id = sender_id
+                 ps.user_id = sender_attrs["user.id"]
++        attributes.update(_session_sender_attributes(tracer, session_id))
+-
++
+     # Opt-in: put the entire conversation the model is about to see on
+     # input.value. Falls back to just the latest user_message otherwise —
+@@ -1638,6 +1650,8 @@ def on_subagent_start(
+         attributes["hermes.subagent.goal"] = goal_preview
+         attributes["input.value"] = goal_preview
+     attributes.update(_correlation_attributes(tracer, parent_session_id, kwargs))
++    sender_attributes = _session_sender_attributes(tracer, parent_session_id)
++    attributes.update(sender_attributes)
+-
++
+     # Nest under the parent session's in-flight span (api/llm/session). The
+     # delegation span is NOT pushed as a parent — the parent session keeps
+@@ -1655,6 +1669,7 @@ def on_subagent_start(
+         "span": span,
+         "role": role,
+         "parent_session_id": parent_session_id,
++        "sender_attributes": sender_attributes,
+     }
+     if span is not None and hasattr(span, "get_span_context"):
+         try:

--- a/docs/env.md
+++ b/docs/env.md
@@ -37,6 +37,10 @@ cp .env.example .env
 
 ```text
 HERMES_IMAGE
+HERMES_BASE_IMAGE
+HERMES_OTEL_REF
+OTEL_PYTHON_VERSION
+PYYAML_VERSION
 OPENVIKING_IMAGE
 HERMES_MAIN_DATA_DIR
 HERMES_OWASHOTA_DATA_DIR
@@ -65,6 +69,19 @@ OAuth token
 ```
 
 root `.env` は、**コンテナをどう起動するか** だけを決めます。
+
+Hermes は `docker/hermes/Dockerfile` から
+`backup-secretary/hermes-agent:local` を再現可能にビルドします。既存の
+root `.env` が古い floating image を指定している場合は、ビルドとテストの
+完了後に次を実行して、将来の Compose recreate でも検証済みローカル image
+を使うようにします。
+
+```bash
+./scripts/set-hermes-runtime-image.sh
+```
+
+このスクリプトは root `.env` だけを対象にし、権限を維持したローカル
+バックアップを作ってから `HERMES_IMAGE` のみを更新します。
 
 ## 2. `runtime/main/hermes-data/.env`
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,90 @@
+# Hermes OpenTelemetry integration
+
+This repository exports approved content-free Hermes telemetry to the separate `local-obserbablity` stack. It does not own an observability backend or expose Grafana.
+
+## Pinned build inputs
+
+| Component | Pin |
+|---|---|
+| Hermes base image | `nousresearch/hermes-agent@sha256:00f57d79b2b20745a4f2c47bd26135f0473100ca23103ffc3eb3f89f3f6cef50` |
+| `briancaffey/hermes-otel` | release 0.11.0, commit `0180c5e63b9d035ee0754d9a0d75c3499a8def26` |
+| OpenTelemetry Python packages | 1.44.0 |
+| PyYAML | 6.0.3 |
+
+The Compose defaults for the other external service images are digest-pinned as well; environment overrides must remain pinned in production.
+
+The reviewed upstream commit emits `hermes.tool.command`, `hermes.tool.target`, their turn rollups, and raw tool error messages even when previews are disabled. A checked-in build-time privacy patch removes those content-bearing attributes while retaining tool names, outcomes, durations, errors as a fixed category, token counts, models, instance identity, and sender identity. The standalone collector independently deletes the same deny-listed attributes as defense in depth.
+
+The Docker build clones exactly the reviewed plugin commit into Hermes' bundled plugin directory and installs dependencies into `/opt/hermes/.venv`. No running container installs plugin code or Python packages.
+
+The pinned Hermes 0.18.2 image already contains the free-response/auto-thread fix in its bundled Discord adapter. The obsolete pre-0.18.2 monkey patch was removed because its former module path no longer exists.
+
+## Data and network path
+
+```text
+Hermes main / owashota
+  -> external Docker network local-observability-net
+  -> http://otel-router:4318
+  -> separate observability router
+       -> private storage
+       -> shared Hermes-only storage
+```
+
+Hermes never connects directly to shared Grafana or storage. The external network must be created by the standalone observability project before Compose validates or starts these services.
+
+## Privacy configuration
+
+Each instance mounts its own reviewed plugin YAML. Environment variables repeat the critical privacy values as defense in depth:
+
+- input/output previews off;
+- conversation history off;
+- full prompts and responses off;
+- general log capture off;
+- sender ID on for per-Discord-user accounting;
+- live dashboard storage off;
+- synchronous session-end flush off to prevent collector downtime blocking a turn.
+
+Only stable operational metadata, model/provider, token counts, timings, errors, tool names/outcomes, instance identity, and Discord sender identity are approved. Never commit a real sender ID, raw trace export, or ID-to-name mapping.
+
+## Build and enable
+
+Prepare the standalone observability project first. Then:
+
+```bash
+docker compose build hermes hermes-owashota
+./scripts/test-hermes-otel-image.sh
+./scripts/enable-hermes-otel.sh
+docker compose up -d --no-build hermes hermes-owashota
+```
+
+The image test checks both privacy configs and loads the plugin through Hermes' real plugin manager in a disposable tmpfs home. The enable helper uses Hermes' supported `plugins enable --no-allow-tool-override` command. It creates one local rollback copy of each existing Hermes config before changing only the plugin allow-list. It does not install into a running container.
+
+Do not execute this against a dirty or unreviewed checkout. Production rollout must use the separate Phase 1 branch/worktree and must preserve the currently running data mounts and secret environment.
+
+## Verification
+
+Before real Discord gate H7:
+
+```bash
+docker compose run --rm --no-deps hermes hermes plugins list
+docker compose run --rm --no-deps hermes-owashota hermes plugins list
+```
+
+Verify `hermes_otel` is enabled and reports no load error. Then inspect startup logs without copying trace payloads. Both gateways must stay healthy when the collector is stopped.
+
+At H7, use one real non-sensitive Discord turn per instance and verify on the owner-only observability side:
+
+- `service.name=backup-secretary-hermes`;
+- `service.namespace=backup-secretary`;
+- `service.instance.id=main` or `owashota`;
+- `hermes.sender.id` and `user.id=discord:<same sender>`;
+- root `agent` span contains rolled-up token attributes;
+- prompt, response, conversation history, tool arguments/results, and general logs are absent.
+
+The same approved Hermes traces must appear in private and shared storage, while personal Codex traces must remain absent from shared storage.
+
+## Rollback
+
+Stop only the two gateways, disable the plugin using Hermes' supported CLI or restore each local `config.yaml.phase1-otel-backup`, and recreate the prior pinned image. Do not delete the backup until both gateways answer normally.
+
+The observability stack can be stopped independently. Its unavailability is not a reason to roll back Hermes unless a reproduced plugin defect affects message handling.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -59,10 +59,11 @@ Only stable operational metadata, model/provider, token counts, timings, errors,
 Prepare the standalone observability project first. Then:
 
 ```bash
-docker compose build hermes hermes-owashota
+docker compose build hermes-main hermes-owashota
 ./scripts/test-hermes-otel-image.sh
 ./scripts/enable-hermes-otel.sh
-docker compose up -d --no-build hermes hermes-owashota
+./scripts/set-hermes-runtime-image.sh
+docker compose up -d --no-build hermes-main hermes-owashota
 ```
 
 The image test checks both privacy configs and loads the plugin through Hermes' real plugin manager in a disposable tmpfs home. The enable helper uses Hermes' supported `plugins enable --no-allow-tool-override` command. It creates one local rollback copy of each existing Hermes config before changing only the plugin allow-list. It does not install into a running container.
@@ -74,7 +75,7 @@ Do not execute this against a dirty or unreviewed checkout. Production rollout m
 Before real Discord gate H7:
 
 ```bash
-docker compose run --rm --no-deps hermes hermes plugins list
+docker compose run --rm --no-deps hermes-main hermes plugins list
 docker compose run --rm --no-deps hermes-owashota hermes plugins list
 ```
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -15,6 +15,14 @@ The Compose defaults for the other external service images are digest-pinned as 
 
 The reviewed upstream commit emits `hermes.tool.command`, `hermes.tool.target`, their turn rollups, and raw tool error messages even when previews are disabled. A checked-in build-time privacy patch removes those content-bearing attributes while retaining tool names, outcomes, durations, errors as a fixed category, token counts, models, instance identity, and sender identity. The standalone collector independently deletes the same deny-listed attributes as defense in depth.
 
+The build also applies a focused patch that propagates the already captured
+parent sender identity to delegated child-agent sessions. This keeps
+content-free child `agent` token rollups attributable to the initiating
+Discord user without capturing any additional identity or message fields. The
+image test exercises a sender-less child LLM/API lifecycle with a synthetic
+parent sender and verifies the child `agent`, `llm.*`, and `api.*` spans retain
+that identity and token rollup without content attributes.
+
 The Docker build clones exactly the reviewed plugin commit into Hermes' bundled plugin directory and installs dependencies into `/opt/hermes/.venv`. No running container installs plugin code or Python packages.
 
 The pinned Hermes 0.18.2 image already contains the free-response/auto-thread fix in its bundled Discord adapter. The obsolete pre-0.18.2 monkey patch was removed because its former module path no longer exists.

--- a/observability/hermes-otel/main.yaml
+++ b/observability/hermes-otel/main.yaml
@@ -1,0 +1,26 @@
+# Reviewed against briancaffey/hermes-otel v0.11.0 at
+# 0180c5e63b9d035ee0754d9a0d75c3499a8def26.
+enabled: true
+resource_attributes:
+  service.name: backup-secretary-hermes
+  service.namespace: backup-secretary
+  service.instance.id: main
+  deployment.environment: home
+
+capture_previews: false
+capture_conversation_history: false
+capture_full_prompts: false
+capture_full_responses: false
+capture_sender_id: true
+capture_logs: false
+emit_genai_metrics: true
+dashboard_live: false
+force_flush_on_session_end: false
+span_batch_export_timeout_ms: 3000
+
+backends:
+  - type: signoz
+    endpoint: http://otel-router:4318/v1/traces
+    traces: true
+    metrics: true
+    logs: false

--- a/observability/hermes-otel/owashota.yaml
+++ b/observability/hermes-otel/owashota.yaml
@@ -1,0 +1,26 @@
+# Reviewed against briancaffey/hermes-otel v0.11.0 at
+# 0180c5e63b9d035ee0754d9a0d75c3499a8def26.
+enabled: true
+resource_attributes:
+  service.name: backup-secretary-hermes
+  service.namespace: backup-secretary
+  service.instance.id: owashota
+  deployment.environment: home
+
+capture_previews: false
+capture_conversation_history: false
+capture_full_prompts: false
+capture_full_responses: false
+capture_sender_id: true
+capture_logs: false
+emit_genai_metrics: true
+dashboard_live: false
+force_flush_on_session_end: false
+span_batch_export_timeout_ms: 3000
+
+backends:
+  - type: signoz
+    endpoint: http://otel-router:4318/v1/traces
+    traces: true
+    metrics: true
+    logs: false

--- a/scripts/enable-hermes-otel.sh
+++ b/scripts/enable-hermes-otel.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+cd -- "${repo_dir}"
+
+if ! docker network inspect local-observability-net >/dev/null 2>&1; then
+  echo "Missing external network local-observability-net; prepare the standalone observability stack first." >&2
+  exit 2
+fi
+
+enable_for_service() {
+  local service=$1
+  local config_owner
+  config_owner=$(docker compose run --rm --no-deps --entrypoint stat "${service}" -c '%u:%g' /opt/data/config.yaml | tail -n 1)
+  if [[ ! "${config_owner}" =~ ^[0-9]+:[0-9]+$ ]]; then
+    echo "Could not determine config.yaml ownership for ${service}." >&2
+    exit 3
+  fi
+  docker compose run --rm --no-deps --user "${config_owner}" --entrypoint bash "${service}" -c '
+    set -euo pipefail
+    umask 077
+    config="${HERMES_HOME}/config.yaml"
+    if [[ ! -f "${config}" ]]; then
+      echo "Missing Hermes config.yaml" >&2
+      exit 4
+    fi
+    backup="${config}.phase1-otel-backup"
+    if [[ ! -e "${backup}" ]]; then
+      cp -- "${config}" "${backup}"
+    fi
+    exec hermes plugins enable --no-allow-tool-override hermes_otel
+  '
+}
+
+enable_for_service hermes
+enable_for_service hermes-owashota
+
+echo "hermes_otel is enabled for main and owashota; original configs have local rollback backups."

--- a/scripts/enable-hermes-otel.sh
+++ b/scripts/enable-hermes-otel.sh
@@ -33,7 +33,7 @@ enable_for_service() {
   '
 }
 
-enable_for_service hermes
+enable_for_service hermes-main
 enable_for_service hermes-owashota
 
 echo "hermes_otel is enabled for main and owashota; original configs have local rollback backups."

--- a/scripts/set-hermes-runtime-image.sh
+++ b/scripts/set-hermes-runtime-image.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+env_file="${repo_dir}/.env"
+image="backup-secretary/hermes-agent:local"
+
+if [[ ! -f "${env_file}" || -L "${env_file}" ]]; then
+  echo "Expected a regular non-symlink root .env at ${env_file}." >&2
+  exit 2
+fi
+
+timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+backup="${env_file}.pre-observability-${timestamp}"
+temporary=$(mktemp "${repo_dir}/.env.tmp.XXXXXX")
+trap 'rm -f -- "${temporary}"' EXIT
+
+cp -p -- "${env_file}" "${backup}"
+awk -v image="${image}" '
+  BEGIN { replaced = 0 }
+  /^HERMES_IMAGE=/ {
+    if (!replaced) {
+      print "HERMES_IMAGE=" image
+      replaced = 1
+    }
+    next
+  }
+  { print }
+  END {
+    if (!replaced) {
+      print "HERMES_IMAGE=" image
+    }
+  }
+' "${env_file}" >"${temporary}"
+
+chmod --reference="${env_file}" "${temporary}"
+mv -- "${temporary}" "${env_file}"
+trap - EXIT
+
+echo "Updated root .env to the verified local Hermes image; prior file retained in an ignored timestamped backup."

--- a/scripts/test-hermes-otel-image.sh
+++ b/scripts/test-hermes-otel-image.sh
@@ -52,6 +52,191 @@ for name in ("main", "owashota"):
 print("CONFIG_ASSERTIONS_OK")
 PY
 
+python - <<'PY'
+import sys
+
+sys.path.insert(0, "/opt/hermes/plugins")
+
+from hermes_otel.hooks import (
+    on_post_api_request,
+    on_post_llm_call,
+    on_pre_api_request,
+    on_pre_llm_call,
+    on_session_end,
+    on_session_start,
+    on_subagent_start,
+    on_subagent_stop,
+)
+from hermes_otel.plugin_config import HermesOtelConfig
+from hermes_otel.tracer import HermesOTelPlugin
+import hermes_otel.tracer as tracer_module
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider(resource=Resource.create({"service.name": "synthetic-test"}))
+provider.add_span_processor(SimpleSpanProcessor(exporter))
+plugin = HermesOTelPlugin(
+    config=HermesOtelConfig(
+        capture_sender_id=True,
+        capture_previews=False,
+        capture_conversation_history=False,
+        capture_full_prompts=False,
+        capture_full_responses=False,
+    )
+)
+plugin.tracer = provider.get_tracer("subagent-sender-test")
+plugin._initialized = True
+tracer_module._tracer = plugin
+
+try:
+    on_session_start(session_id="parent", model="test-model", platform="discord")
+    on_pre_llm_call(
+        session_id="parent",
+        user_message="synthetic",
+        conversation_history=[],
+        is_first_turn=True,
+        model="test-model",
+        platform="discord",
+        sender_id="synthetic-user",
+    )
+    on_subagent_start(
+        parent_session_id="parent",
+        child_session_id="child",
+        child_role="synthetic-role",
+    )
+    on_session_start(session_id="child", model="test-model", platform="subagent")
+    on_pre_llm_call(
+        session_id="child",
+        user_message="synthetic child input",
+        conversation_history=[],
+        is_first_turn=True,
+        model="test-model",
+        platform="subagent",
+    )
+    on_pre_api_request(
+        task_id="child-task",
+        session_id="child",
+        platform="subagent",
+        model="test-model",
+        provider="synthetic-provider",
+        base_url="https://invalid.example",
+        api_mode="chat",
+        api_call_count=1,
+        message_count=1,
+        tool_count=0,
+        approx_input_tokens=11,
+        request_char_count=21,
+        max_tokens=100,
+    )
+    on_post_api_request(
+        task_id="child-task",
+        session_id="child",
+        platform="subagent",
+        model="test-model",
+        provider="synthetic-provider",
+        base_url="https://invalid.example",
+        api_mode="chat",
+        api_call_count=1,
+        api_duration=0.01,
+        finish_reason="stop",
+        message_count=1,
+        response_model="test-model",
+        usage={
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "total_tokens": 18,
+            "cache_read_tokens": 3,
+            "reasoning_tokens": 2,
+        },
+        assistant_content_chars=22,
+        assistant_tool_call_count=0,
+    )
+    on_post_llm_call(
+        session_id="child",
+        user_message="synthetic child input",
+        assistant_response="synthetic child output",
+        conversation_history=[],
+        model="test-model",
+        platform="subagent",
+    )
+    on_session_end(
+        session_id="child",
+        completed=True,
+        interrupted=False,
+        model="test-model",
+        platform="subagent",
+    )
+    on_subagent_stop(
+        parent_session_id="parent",
+        child_session_id="child",
+        child_role="synthetic-role",
+        child_status="completed",
+    )
+    on_post_llm_call(
+        session_id="parent",
+        user_message="synthetic",
+        assistant_response="synthetic",
+        conversation_history=[],
+        model="test-model",
+        platform="discord",
+    )
+    on_session_end(
+        session_id="parent",
+        completed=True,
+        interrupted=False,
+        model="test-model",
+        platform="discord",
+    )
+
+    finished_spans = exporter.get_finished_spans()
+    child_spans = [
+        span
+        for span in finished_spans
+        if dict(span.attributes).get("session.id") == "child"
+    ]
+    assert {span.name for span in child_spans} == {
+        "agent",
+        "api.test-model",
+        "llm.test-model",
+    }
+    for span in child_spans:
+        attributes = dict(span.attributes)
+        assert attributes["hermes.sender.id"] == "synthetic-user"
+        assert attributes["user.id"] == "discord:synthetic-user"
+        assert attributes.get("hermes.sender.id") != "None"
+        assert attributes.get("user.id") != "subagent:None"
+        for blocked_key in (
+            "input.value",
+            "output.value",
+            "gen_ai.input.messages",
+            "gen_ai.output.messages",
+            "llm.input_messages",
+            "llm.output.content",
+        ):
+            assert blocked_key not in attributes
+
+    child_agent = next(span for span in child_spans if span.name == "agent")
+    child_attributes = dict(child_agent.attributes)
+    assert child_attributes["gen_ai.usage.input_tokens"] == 11
+    assert child_attributes["gen_ai.usage.output_tokens"] == 7
+    assert child_attributes["gen_ai.usage.total_tokens"] == 18
+    assert child_attributes["gen_ai.usage.cache_read.input_tokens"] == 3
+    assert child_attributes["gen_ai.usage.reasoning.output_tokens"] == 2
+
+    delegation = next(span for span in finished_spans if span.name == "subagent.synthetic-role")
+    delegation_attributes = dict(delegation.attributes)
+    assert delegation_attributes["hermes.sender.id"] == "synthetic-user"
+    assert delegation_attributes["user.id"] == "discord:synthetic-user"
+    print("SUBAGENT_SENDER_INHERITANCE_OK")
+finally:
+    provider.shutdown()
+    tracer_module._tracer = None
+PY
+
 hermes plugins enable --no-allow-tool-override hermes_otel >/dev/null
 python - <<'PY'
 from hermes_cli.plugins import get_plugin_manager

--- a/scripts/test-hermes-otel-image.sh
+++ b/scripts/test-hermes-otel-image.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+image=${1:-backup-secretary/hermes-agent:local}
+
+docker run --rm -i \
+  --network local-observability-net \
+  --tmpfs /opt/testhome:rw,nosuid,size=32m,uid=1000,gid=1000,mode=0700 \
+  -e HOME=/opt/testhome \
+  -e HERMES_HOME=/opt/testhome \
+  -v "${repo_dir}/observability/hermes-otel/main.yaml:/run/main.yaml:ro" \
+  -v "${repo_dir}/observability/hermes-otel/owashota.yaml:/run/owashota.yaml:ro" \
+  --entrypoint bash \
+  "${image}" -s <<'CONTAINER_SCRIPT'
+set -euo pipefail
+mkdir -p "${HOME}/.hermes/plugins/hermes_otel"
+cp /run/main.yaml "${HOME}/.hermes/plugins/hermes_otel/config.yaml"
+
+python - <<'PY'
+from pathlib import Path
+import sys
+
+sys.path.insert(0, "/opt/hermes/plugins")
+from hermes_otel.plugin_config import load_config
+
+hooks_source = Path("/opt/hermes/plugins/hermes_otel/hooks.py").read_text()
+for blocked_key in (
+    "hermes.tool.command",
+    "hermes.tool.target",
+    "hermes.turn.tool_commands",
+    "hermes.turn.tool_targets",
+    "error.message",
+):
+    assert f'"{blocked_key}"' not in hooks_source
+
+for name in ("main", "owashota"):
+    cfg = load_config(path=Path(f"/run/{name}.yaml"))
+    attrs = cfg.resource_attributes
+    assert attrs["service.name"] == "backup-secretary-hermes"
+    assert attrs["service.namespace"] == "backup-secretary"
+    assert attrs["service.instance.id"] == name
+    assert cfg.capture_previews is False
+    assert cfg.capture_conversation_history is False
+    assert cfg.capture_full_prompts is False
+    assert cfg.capture_full_responses is False
+    assert cfg.capture_sender_id is True
+    assert cfg.capture_logs is False
+    assert cfg.force_flush_on_session_end is False
+    assert cfg.backends
+    assert cfg.backends[0].endpoint == "http://otel-router:4318/v1/traces"
+print("CONFIG_ASSERTIONS_OK")
+PY
+
+hermes plugins enable --no-allow-tool-override hermes_otel >/dev/null
+python - <<'PY'
+from hermes_cli.plugins import get_plugin_manager
+
+manager = get_plugin_manager()
+manager.discover_and_load(force=True)
+matches = [
+    loaded for key, loaded in manager._plugins.items()
+    if key == "hermes_otel" or loaded.manifest.name == "hermes_otel"
+]
+assert matches
+assert matches[0].enabled is True
+assert not matches[0].error
+print("PLUGIN_LOAD_OK")
+PY
+
+hermes plugins list --enabled --json | python -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+rows = data if isinstance(data, list) else data.get("plugins", [])
+matches = [
+    row for row in rows
+    if row.get("name") == "hermes_otel" or row.get("key") == "hermes_otel"
+]
+assert matches
+assert matches[0].get("status") == "enabled"
+print("PLUGIN_ENABLED_OK")
+'
+CONTAINER_SCRIPT


### PR DESCRIPTION
## What changed

- integrate the merged pinned Hermes OTel image and delegated-session user fix into the active `hermes-main` / `hermes-owashota` Compose topology
- preserve the runtime branch's OpenViking, SearXNG/Valkey, per-instance data/env paths, and localhost gateway bindings
- attach only the two Hermes gateways to `local-observability-net`
- mount separate privacy-safe OTel configuration for both instances and add process health checks
- make the verified local image the documented default and add a guarded root `.env` migration helper
- correct plugin-enable and runbook commands for the runtime branch's `hermes-main` service name

## Why

The running containers already use the verified fixed image and observability network, but the active runtime branch did not persist those settings. A future Compose recreation could therefore fall back to a floating upstream image and lose telemetry connectivity.

## Validation

- conflicts were resolved in a separate clean worktree; the dirty live checkout was not edited
- resolved Compose configuration validates against the live local path/env layout without exposing secret values
- the rendered service set remains exactly `hermes-main`, `hermes-owashota`, `openviking`, `searxng`, and `valkey`
- both Hermes services resolve to the verified local image and external observability network
- privacy settings keep previews/history/full prompts/full responses/logs disabled and sender capture enabled
- all shell scripts pass syntax checks
- the deployed reviewed image passes configuration, sender inheritance, plugin load, and plugin-enable assertions

## Deployment safety

Merging this PR changes source control only. It does not recreate running containers. The root `.env` helper is idempotent, backs up the prior file, preserves its mode, and changes only `HERMES_IMAGE`.