### PR TITLE
feat: add Codex usage Discord presence plugin

### DIFF
--- a/plugins/discord-presence/DEPLOYMENT-RUNBOOK.md
+++ b/plugins/discord-presence/DEPLOYMENT-RUNBOOK.md
@@ -1,0 +1,416 @@
+# Discord Presence Deployment Runbook — server-side Codex用
+
+この文書は、稼働中のDiscord Hermes自身ではなく、**サーバー側のCodex CLI**が実行するための手順です。
+Gateway再起動でDiscord Hermesが応答不能になっても、Codex CLIのshell sessionは維持し、そこで検証・rollbackまで完結させます。
+
+## 0. 絶対条件
+
+- 対象Hermes: `/opt/hermes` v0.18.2
+- config: `/opt/data/config.yaml`
+- plugin: `/opt/data/plugins/discord-presence`
+- service: `/run/service/gateway-default`
+- log: `/opt/data/logs/gateways/default/current`
+- Hermes本体 `/opt/hermes` は編集しない。
+- plugin production codeもdeployment中には編集しない。
+- Codexはread-onlyの以下だけを使用する。
+  - `account/rateLimits/read`
+  - `account/usage/read`
+- Codexの手動reset、reset credit消費、認証変更を行わない。
+- configやlogの生内容、token、credential、raw Codex responseをchatへ貼らない。
+- Gateway restartは本番反映で1回、rollback時に必要なら追加1回まで。
+- preflightが1つでも失敗したらrestartしない。
+- すべてのshell blockは`bash`で実行する。`sh`では実行しない（`source`と`printf %q`を使用するため）。
+
+## 1. どこで死ぬか
+
+| ポイント | 想定障害 | Discord Hermesへの影響 | Codexの対応 |
+|---|---|---|---|
+| config編集 | YAML破損・既存key上書き | **次回restart後にGatewayが起動不能**。編集直後は旧processが動く | restartせずbackupへ復元 |
+| plugin enable | configへのenabled登録失敗 | restart前は影響なし | backupへ復元、終了 |
+| plugin import/register | import error・Hermes API差異 | Gatewayは起動してもDiscord adapterが登録されない可能性 | 新規logを検査し即rollback |
+| Discord adapter connect | `connect(is_reconnect)`等の互換性不良 | **GatewayはupでもDiscord Botだけoffline**になり得る | stable PIDだけで成功扱いせずlog検査、失敗ならrollback |
+| disconnect/restart | cleanup timeout・子process残存 | restart timeoutまたは一時offline | s6 statusをpoll。30秒以内に安定しなければrollback |
+| Codex usage取得 | OAuth切れ・CLI不在・API変更 | 原則Bot chatは生存し、`Codex利用量 取得待ち`へfallback | chatが正常なら非致命。後で原因調査 |
+| Discord presence送信 | Discord API拒否・CustomActivity非表示 | 原則Bot chatは生存。presenceのみ失敗 | chat優先。繰り返しerrorならrollback |
+| rollback | backup不正・復元後も起動不能 | **Discord Hermesがoffline継続** | server-side Codexがs6/logを追跡し、backupを保持して停止。盲目的な再restart loopは禁止 |
+
+plugin側ではcancel時のCodex子process終了・待機queue起床・worker終了待ちを実装し単体/実process smoke済みだが、deployment時にも新規logとPID安定性を再確認する。
+
+**本当に致命的なのは、config破損、plugin登録失敗、Discord adapter接続失敗、rollback失敗です。**
+Codex取得失敗とpresence表示失敗は、設計上はBot chatを殺さないfailureです。
+
+## 2. Codexへ渡す指示
+
+```text
+/opt/data/plugins/discord-presence/DEPLOYMENT-RUNBOOK.md を最初から最後まで読み、記載順に実行してください。
+Hermes本体は変更禁止。configは必ずbackup後に変更。preflight失敗時はrestart禁止。
+Gateway restart後にDiscord Hermesが応答不能でも、あなたのserver shellからs6 status・新規logを確認し、条件に該当すれば自律rollbackしてください。
+秘密値・config全文・raw Codex responseは出力しないでください。
+完了報告には、旧新PID、テスト件数、plugin status、rollback有無、server-side acceptance結果だけを書いてください。
+```
+
+## 3. Phase A — 現状固定とbackup
+
+Codexの各terminal callは環境変数を引き継ぐとは限らない。Phase Aで非秘密のdeployment stateを保存し、**Phase B以降は各terminal callの先頭で必ずsourceする**。
+
+```bash
+set -euo pipefail
+
+HERMES=/opt/hermes/.venv/bin/hermes
+PY=/opt/hermes/.venv/bin/python3
+CONFIG=/opt/data/config.yaml
+PLUGIN=/opt/data/plugins/discord-presence
+SERVICE=/run/service/gateway-default
+LOG=/opt/data/logs/gateways/default/current
+STATE=/opt/data/backups/discord-presence-current.env
+STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+BACKUP=/opt/data/backups/discord-presence-$STAMP
+
+mkdir -p -m 700 "$BACKUP"
+cp -a "$CONFIG" "$BACKUP/config.yaml"
+sha256sum "$CONFIG" > "$BACKUP/config.sha256"
+stat -c '%a %U:%G' "$CONFIG" > "$BACKUP/config.metadata"
+/command/s6-svstat "$SERVICE" > "$BACKUP/gateway-before.txt"
+OLD_PID=$(/command/s6-svstat "$SERVICE" | sed -n 's/.*pid \([0-9][0-9]*\).*/\1/p')
+test -n "$OLD_PID"
+LOG_OFFSET=$(stat -c %s "$LOG")
+printf '%s\n' "$LOG_OFFSET" > "$BACKUP/log-offset"
+printf '%s\n' "$OLD_PID" > "$BACKUP/old-pid"
+
+umask 077
+{
+  printf 'HERMES=%q\n' "$HERMES"
+  printf 'PY=%q\n' "$PY"
+  printf 'CONFIG=%q\n' "$CONFIG"
+  printf 'PLUGIN=%q\n' "$PLUGIN"
+  printf 'SERVICE=%q\n' "$SERVICE"
+  printf 'LOG=%q\n' "$LOG"
+  printf 'BACKUP=%q\n' "$BACKUP"
+  printf 'OLD_PID=%q\n' "$OLD_PID"
+  printf 'LOG_OFFSET=%q\n' "$LOG_OFFSET"
+} > "$STATE"
+```
+
+backupにconfigの秘密値が含まれるので、`$BACKUP`のpathやchecksumは報告してよいが、内容は表示しない。
+現在のconfig mode/ownerをそのまま保持する。2026-07-30時点では`0640 hermes:hermes`だが、固定値に決め打ちせずbackup metadataを正とする。
+
+## 4. Phase B — restart前preflight
+
+```bash
+set -euo pipefail
+source /opt/data/backups/discord-presence-current.env
+cd "$PLUGIN"
+"$PY" -m compileall -q .
+"$PY" -m unittest discover -s tests -v
+"$HERMES" plugins list | grep 'discord-presence'
+/command/s6-svstat "$SERVICE"
+```
+
+期待値:
+
+- unit tests: 30件以上、全件`OK`
+- `discord-presence`: `not enabled`
+- Gateway: `up`
+- plugin sourceの本番Pythonに禁止語がない
+
+```bash
+set -euo pipefail
+source /opt/data/backups/discord-presence-current.env
+if grep -R -nE 'rateLimitResetCredit|discord\.Game|ActivityType\.playing|shell=True|os\.system\(|pickle\.load' \
+  --include='*.py' "$PLUGIN"; then
+  echo 'STOP: forbidden production pattern found' >&2
+  exit 1
+fi
+```
+
+実Codex read-only smoke。利用率値やraw responseは出力しない。
+
+```bash
+set -euo pipefail
+source /opt/data/backups/discord-presence-current.env
+cd /opt/hermes
+"$PY" - <<'PY'
+import importlib.util, sys, time
+from pathlib import Path
+sys.path.insert(0, '/opt/hermes')
+r = Path('/opt/data/plugins/discord-presence')
+s = importlib.util.spec_from_file_location(
+    'deploy_smoke', r / '__init__.py', submodule_search_locations=[str(r)]
+)
+m = importlib.util.module_from_spec(s)
+sys.modules[s.name] = m
+s.loader.exec_module(m)
+from deploy_smoke.collector import fetch_codex_snapshot
+from deploy_smoke.presence_config import PresenceConfig
+from deploy_smoke.renderer import render_presence, build_custom_activity
+x = fetch_codex_snapshot(timeout=15)
+text = render_presence(x, PresenceConfig(enabled=True))
+payload = build_custom_activity(text).to_dict()
+assert x.remaining_percent is None or 0 <= x.remaining_percent <= 100
+assert payload['type'] == 4
+assert len(text) <= 120
+print('codex_read=ok custom_activity=type4 secret_output=none')
+PY
+```
+
+ここまでで失敗したら、**configを変更せず終了**する。
+
+## 5. Phase C — plugin enableとpresence config追加
+
+まず公式CLIでpluginをenableする。tool override権限は与えない。
+
+```bash
+set -euo pipefail
+source /opt/data/backups/discord-presence-current.env
+"$HERMES" plugins enable --no-allow-tool-override discord-presence
+```
+
+次にpresence blockをatomicに追加する。既にtop-level `discord`が存在した場合は自動上書きせずSTOPする。
+
+```bash
+set -euo pipefail
+source /opt/data/backups/discord-presence-current.env
+CONFIG="$CONFIG" "$PY" - <<'PY'
+import os
+from pathlib import Path
+import yaml
+
+p = Path(os.environ['CONFIG'])
+raw = p.read_text(encoding='utf-8')
+cfg = yaml.safe_load(raw)
+if not isinstance(cfg, dict):
+    raise SystemExit('STOP: config root is not a mapping')
+if 'discord' in cfg:
+    raise SystemExit('STOP: top-level discord already exists; do not overwrite automatically')
+
+block = '''
+
+discord:
+  presence:
+    enabled: true
+    mode: rate_limit
+    template: "Codex残量 {remaining_percent}%｜次回リセット {reset_time_jst}"
+    bucket_id: codex
+    refresh_seconds: 300
+    stale_after_seconds: 900
+    fallback_text: "Codex利用量 取得待ち"
+    timezone: Asia/Tokyo
+    max_length: 120
+'''
+
+st = p.stat()
+tmp = p.with_name(p.name + '.discord-presence.tmp')
+tmp.write_text(raw.rstrip() + block, encoding='utf-8')
+yaml.safe_load(tmp.read_text(encoding='utf-8'))
+os.chmod(tmp, st.st_mode & 0o7777)
+os.chown(tmp, st.st_uid, st.st_gid)
+os.replace(tmp, p)
+PY
+```
+
+secretを表示せず、必要な状態だけ検証する。
+
+```bash
+set -euo pipefail
+source /opt/data/backups/discord-presence-current.env
+CONFIG="$CONFIG" "$PY" - <<'PY'
+import os, yaml
+with open(os.environ['CONFIG'], encoding='utf-8') as f:
+    c = yaml.safe_load(f)
+p = c.get('plugins', {})
+assert 'discord-presence' in p.get('enabled', [])
+assert p.get('entries', {}).get('discord-presence', {}).get('allow_tool_override') is False
+d = c.get('discord', {}).get('presence', {})
+assert d.get('enabled') is True
+assert d.get('mode') == 'rate_limit'
+assert d.get('timezone') == 'Asia/Tokyo'
+print('config_semantics=ok plugin_enabled=true presence_enabled=true secrets_printed=false')
+PY
+
+"$HERMES" config check
+"$HERMES" plugins list | grep 'discord-presence'
+stat -c '%a %U:%G' "$CONFIG"
+```
+
+期待値:
+
+- `discord-presence`: enabled
+- config check: exit 0
+- config mode/owner: backup前と同じ
+
+このPhaseで失敗した場合、restartせずPhase Hの「restart前rollback」を実行する。
+
+## 6. Phase D — restart直前の最終gate
+
+```bash
+set -euo pipefail
+source /opt/data/backups/discord-presence-current.env
+cd "$PLUGIN"
+"$PY" -m compileall -q .
+"$PY" -m unittest discover -s tests -v
+/command/s6-svstat "$SERVICE"
+```
+
+以下が1つでも真ならSTOPしてrestart前rollback:
+
+- tests失敗
+- Gatewayが既にdown
+- pluginがenabledでない
+- config check失敗
+- config owner/modeが変化
+- backupが読めない
+
+## 7. Phase E — Gatewayを1回だけrestart
+
+```bash
+set -euo pipefail
+source /opt/data/backups/discord-presence-current.env
+/command/s6-svc -r "$SERVICE"
+```
+
+30秒以内に、旧PIDと異なる`up`状態を確認する。
+
+```bash
+set -euo pipefail
+source /opt/data/backups/discord-presence-current.env
+NEW_PID=''
+for _ in $(seq 1 30); do
+  STATUS=$(/command/s6-svstat "$SERVICE" || true)
+  PID=$(printf '%s\n' "$STATUS" | sed -n 's/.*pid \([0-9][0-9]*\).*/\1/p')
+  if printf '%s' "$STATUS" | grep -q '^up ' && [ -n "$PID" ] && [ "$PID" != "$OLD_PID" ]; then
+    NEW_PID=$PID
+    break
+  fi
+  sleep 1
+done
+
+test -n "$NEW_PID" || { echo 'FAIL: gateway did not return with a new PID'; false; }
+sleep 10
+STABLE_PID=$(/command/s6-svstat "$SERVICE" | sed -n 's/.*pid \([0-9][0-9]*\).*/\1/p')
+test "$STABLE_PID" = "$NEW_PID" || { echo 'FAIL: gateway PID is not stable'; false; }
+printf '%s\n' "$NEW_PID" > "$BACKUP/new-pid"
+```
+
+このshellが失敗したら即Phase Hの「restart後rollback」へ進む。Discord Hermesへ質問してはいけない。offlineの可能性がある。
+
+## 8. Phase F — 新規logだけ検査
+
+restart前のbyte offset以降だけを抽出する。log rotationでfileが短くなった場合はcurrent全体を対象にする。
+
+```bash
+set -euo pipefail
+source /opt/data/backups/discord-presence-current.env
+LOG="$LOG" OFFSET="$LOG_OFFSET" OUT="$BACKUP/post-restart.log" "$PY" - <<'PY'
+import os
+from pathlib import Path
+p = Path(os.environ['LOG'])
+data = p.read_bytes()
+offset = int(os.environ['OFFSET'])
+new = data[offset:] if len(data) >= offset else data
+Path(os.environ['OUT']).write_bytes(new)
+print(f'post_restart_log_bytes={len(new)}')
+PY
+```
+
+`post-restart.log`は秘密を含む可能性があるため、全文をchatへ貼らない。ローカルでのみ検索する。
+
+```bash
+set -euo pipefail
+source /opt/data/backups/discord-presence-current.env
+if grep -Eiq \
+  'Failed to load plugin.*discord-presence|Traceback|ModuleNotFoundError|ImportError|unexpected keyword argument.*is_reconnect|Task exception was never retrieved|discord.*connect.*(fail|error)|presence.*(fail|error)' \
+  "$BACKUP/post-restart.log"; then
+  echo 'FAIL: fatal pattern in new gateway log' >&2
+  false
+fi
+
+/command/s6-svstat "$SERVICE"
+"$HERMES" plugins list | grep 'discord-presence'
+```
+
+grep結果にもcredentialらしき値があれば外部へ貼らず`[REDACTED]`にする。
+
+## 9. Phase G — acceptance
+
+server-side Codexが確認できるもの:
+
+- Gatewayが新PIDで10秒以上stable
+- pluginがenabled
+- 新規logにimport/connect/task/presence errorなし
+- read-only Codex smoke成功
+- unit tests成功
+- config ownership/mode保持
+
+Discord外部クライアントなしでは完全確認できないもの:
+
+- メンバー一覧で本当に`Playing`なしのCustom Statusとして見えるか
+- Discord上の通常メッセージにBotが応答するか
+
+Gatewayの`change_presence()`には表示反映のACKがないため、server-side検証だけでUI反映を捏造してはいけない。上記2点は「server側異常なし・外部UI確認待ち」と明記する。
+
+## 10. Phase H — rollback
+
+### restart前rollback
+
+Gatewayは旧processのままなのでrestartしない。backup configをatomicに戻す。
+
+```bash
+set -euo pipefail
+source /opt/data/backups/discord-presence-current.env
+cp -a "$BACKUP/config.yaml" "$CONFIG.rollback"
+mv -f "$CONFIG.rollback" "$CONFIG"
+sha256sum -c "$BACKUP/config.sha256"
+/command/s6-svstat "$SERVICE"
+```
+
+### restart後rollback
+
+configが壊れているとHermes CLI自身が使えない可能性があるため、`hermes plugins disable`には依存しない。backupファイルを直接atomic restoreする。
+
+```bash
+set -euo pipefail
+source /opt/data/backups/discord-presence-current.env
+cp -a "$BACKUP/config.yaml" "$CONFIG.rollback"
+mv -f "$CONFIG.rollback" "$CONFIG"
+sha256sum -c "$BACKUP/config.sha256"
+/command/s6-svc -r "$SERVICE"
+
+ROLLBACK_PID=''
+for _ in $(seq 1 30); do
+  STATUS=$(/command/s6-svstat "$SERVICE" || true)
+  PID=$(printf '%s\n' "$STATUS" | sed -n 's/.*pid \([0-9][0-9]*\).*/\1/p')
+  if printf '%s' "$STATUS" | grep -q '^up ' && [ -n "$PID" ]; then
+    ROLLBACK_PID=$PID
+    break
+  fi
+  sleep 1
+done
+
+test -n "$ROLLBACK_PID"
+sleep 10
+test "$ROLLBACK_PID" = "$(/command/s6-svstat "$SERVICE" | sed -n 's/.*pid \([0-9][0-9]*\).*/\1/p')"
+```
+
+rollback後も起動しない場合:
+
+- 追加restartを繰り返さない。
+- backup、post-restart log、s6 statusを保持。
+- config全文やsecretを表示せず、server管理者へ`Gateway rollback failed`と報告。
+- plugin directoryは削除しない。backup configではpluginがenabledでないためロードされない。
+
+## 11. 最終報告format
+
+```text
+Deployment: SUCCESS / ROLLED BACK / BLOCKED BEFORE RESTART
+Old PID: <pid>
+New PID: <pid or none>
+Gateway stable: yes/no
+Unit tests: <N> passed
+Plugin status: enabled/not enabled
+Codex read smoke: ok/failed
+New fatal log patterns: none/found
+Config metadata preserved: yes/no
+Rollback performed: yes/no
+Discord UI/chat: externally verified / external verification unavailable
+Secrets printed: no
+```

--- a/plugins/discord-presence/README.md
+++ b/plugins/discord-presence/README.md
@@ -1,0 +1,275 @@
+# Discord Codex Usage Presence
+
+Hermesの既存Discord adapterを継承し、Discord BotのCustom ActivityへCodex利用量を表示するuser pluginです。
+
+```text
+Codex残量 73%｜次回リセット 07/30 18:00
+```
+
+`discord.CustomActivity`（Gateway activity type 4）を使うため、`Playing`等の接頭辞は付きません。
+
+## 現在の導入状態
+
+このdirectoryが存在するだけではpluginは動きません。Hermes user pluginはopt-in方式です。
+
+```text
+Plugin files: installed for development
+plugins.enabled: not changed
+Discord presence config: not changed
+Gateway restart: not performed
+Live Discord update: not performed
+```
+
+`hermes plugins list`では`discord-presence / not enabled`と表示されるのが、導入前の正常状態です。
+
+## 安全設計
+
+- Hermes本体 `/opt/hermes` を編集しません。
+- 既存Discord adapterをsubclass化し、元の登録metadataと機能を再利用します。
+- `discord-auto-thread-recovery` pluginが先に適用されていても、そのclassを継承して両機能を維持します。
+- Codex app-serverの読み取り専用methodだけを呼びます。
+  - `account/rateLimits/read`
+  - `account/usage/read`
+- reset creditの消費、認証変更、thread作成等は行いません。
+- credential、account ID、plan、balance、raw responseを表示・log出力しません。
+- 更新間隔は最低60秒、default 300秒です。
+- 同じ文言はDiscordへ再送しません。
+- Codex取得失敗時もDiscord chat機能を停止しません。
+- 一時失敗時は前回値を維持し、default 15分後にfallback表示へ移行します。
+- disconnect/reconnect時はCodex app-serverをterminateし、待機中JSON-RPC queueを起床してworker終了まで待ちます。
+- Presence停止と既存Discord adapterのcleanupは並行開始し、Gatewayの5秒disconnect budgetを妨げません。
+
+## ファイル
+
+```text
+discord-presence/
+├── plugin.yaml
+├── __init__.py
+├── plugin_entry.py
+├── adapter.py
+├── collector.py
+├── presence_config.py
+├── renderer.py
+├── README.md
+└── tests/
+```
+
+## 設定
+
+初回導入時に、`/opt/data/config.yaml`へ次を追加します。**現在はまだ追加しません。**
+
+```yaml
+discord:
+  presence:
+    enabled: true
+    mode: rate_limit
+    template: "Codex残量 {remaining_percent}%｜次回リセット {reset_time_jst}"
+    bucket_id: codex
+    refresh_seconds: 300
+    stale_after_seconds: 900
+    fallback_text: "Codex利用量 取得待ち"
+    timezone: Asia/Tokyo
+    max_length: 120
+```
+
+さらにpluginをenableします。
+
+```bash
+/opt/hermes/.venv/bin/hermes plugins enable discord-presence
+```
+
+このcommandは`config.yaml`を変更するため、承認済みのメンテナンス時だけ実行します。
+
+### mode
+
+| mode | 内容 |
+|---|---|
+| `rate_limit` | Codex rate limitの使用率・残量・reset時刻 |
+| `daily_tokens` | account usageの最新daily bucket |
+| `combined` | templateで利用率とdaily tokensを併記 |
+| `static` | Codex APIを呼ばず`static_text`を表示 |
+
+### template placeholders
+
+```text
+{remaining_percent}
+{used_percent}
+{reset_time_jst}
+{window_minutes}
+{latest_date}
+{latest_tokens}
+{latest_tokens_short}
+```
+
+`{reset_time_jst}`は`MM/DD HH:MM`形式です。週次枠のresetが翌日以降でも、
+日付を落とさず表示します。
+
+上記以外のplaceholder、attribute access、format conversionは拒否されます。
+
+例:
+
+```yaml
+# 残量だけ
+template: "Codex残量 {remaining_percent}%"
+
+# 最新daily tokenも表示
+mode: combined
+template: "Codex {remaining_percent}%｜{latest_date} {latest_tokens_short} tok"
+
+# API切り分け用
+mode: static
+static_text: "Hermes ready"
+```
+
+### Hot reload
+
+controllerは各更新周期でconfigを読み直します。以下はGateway再起動なしで次tickに反映されます。
+
+- `enabled`
+- `mode`
+- `template`
+- `bucket_id`
+- `refresh_seconds`
+- `stale_after_seconds`
+- `fallback_text`
+- `timezone`
+- `max_length`
+- `static_text`
+
+Python code、plugin enable/disable、plugin追加・削除にはGateway再起動が必要です。
+
+## 開発テスト
+
+外部package追加なしで、HermesのPythonから全unit testsを実行できます。
+
+```bash
+cd /opt/data/plugins/discord-presence
+/opt/hermes/.venv/bin/python3 -m unittest discover -s tests -v
+```
+
+検証範囲:
+
+- config default・clamp・hot reload
+- rate limit bucket選択
+- percentage境界値
+- daily bucket選択
+- error messageのsecret非露出
+- JST変換
+- token短縮
+- template allowlist
+- Custom Activity type 4 payload
+- 文字数上限
+- 重複更新抑止
+- stale fallback
+- Discord update再試行
+- enable/disable
+- task start/stop/reconnect
+- 進行中Codex取得のcancel、worker join、子process終了
+- Hermes v0.18.2の`connect(is_reconnect=...)`契約
+- 既存adapterとの継承合成
+- plugin registration idempotency
+
+## 導入前preflight
+
+設定変更・再起動前に以下をすべて通します。
+
+```bash
+# 1. Unit tests
+cd /opt/data/plugins/discord-presence
+/opt/hermes/.venv/bin/python3 -m unittest discover -s tests -v
+
+# 2. Syntax/import check
+/opt/hermes/.venv/bin/python3 -m compileall -q .
+
+# 3. Manifest discovery（まだnot enabledであること）
+/opt/hermes/.venv/bin/hermes plugins list
+
+# 4. Gateway status
+/command/s6-svstat /run/service/gateway-default
+```
+
+Codex live smokeは読み取り専用methodだけで実施します。現在の利用率値自体はlogへ出さず、範囲・render・activity typeだけを検証します。
+
+## 初回導入手順
+
+この節は、設定変更と夜間再起動の明示承認後だけ実行します。
+
+1. 現在のGateway PIDとstatusを保存。
+2. `/opt/data/config.yaml`をmode 600でtimestamp付きbackup。
+3. 上記`discord.presence` blockを追加。
+4. `hermes plugins enable discord-presence`を実行。
+5. `hermes plugins list`でenabledを確認。
+6. 全unit tests、syntax、registration、Codex read smokeを再実行。
+7. config差分を確認し、token・secretが出力されないようにする。
+8. 再起動直前にもう一度承認を得る。
+9. Gatewayを一回だけrestart。
+
+現在のs6環境でのrestart候補:
+
+```bash
+/command/s6-svc -r /run/service/gateway-default
+```
+
+実行時にはservice pathを再確認し、環境が変わっていたら盲目的に使いません。
+
+## 再起動後のacceptance test
+
+1. `/command/s6-svstat /run/service/gateway-default`が`up`。
+2. Gateway PIDが新しくなっている。
+3. logにplugin import error、task exception、Discord connection errorがない。
+4. Discord Botが通常メッセージへ応答する。
+5. Bot profile/member listに`Playing`なしのプレーンテキストが出る。
+6. 5分後もpresence taskが1本で、同一文言を無駄に再送しない。
+7. `template`を一時変更し、再起動なしで次tickに反映される。
+8. 本番templateへ戻し、再反映を確認する。
+
+Discordクライアント側の表示はGateway payloadだけでは完全保証できないため、最終acceptanceには目視確認を含めます。
+
+## Troubleshooting
+
+### `Codex利用量 取得待ち`
+
+- Codex OAuth状態を確認。
+- `codex` CLIがGatewayのPATHで実行可能か確認。
+- read method schemaが現在のCodex CLIに存在するか確認。
+- raw credentialやraw responseをlogへ貼らない。
+
+### presenceが表示されない
+
+- `hermes plugins list`でplugin enabledを確認。
+- `discord.presence.enabled: true`を確認。
+- Gateway restart後のimport errorを確認。
+- `mode: static`でDiscord update経路だけを切り分ける。
+
+### 通常のDiscord応答に影響がある
+
+presenceよりBot chatを優先し、直ちにrollbackします。
+
+## Rollback
+
+まずhot reloadでpresenceだけ停止できます。
+
+```yaml
+discord:
+  presence:
+    enabled: false
+```
+
+通常応答に影響がある場合:
+
+1. `hermes plugins disable discord-presence`
+2. backupした`config.yaml`を復元
+3. 夜間枠内でGatewayを一回restart
+4. Discord接続・通常応答を確認
+
+plugin directoryは原因調査が終わるまで削除しません。
+
+## Hermes/Codex update後の互換性確認
+
+- bundled Discord adapterにasync `connect()` / `disconnect()`と`_client`がある。
+- `upstream.DiscordAdapter`のsubclass化が可能。
+- discord.pyに`CustomActivity`がある。
+- Codex app-serverに2つのread methodがある。
+- 全unit testsとreal registration smokeが通る。
+
+一つでも失敗した場合はpluginをdisabledのままにし、Gatewayを再起動しません。

--- a/plugins/discord-presence/__init__.py
+++ b/plugins/discord-presence/__init__.py
@@ -1,0 +1,5 @@
+"""Discord custom presence plugin for Hermes Agent."""
+
+from .plugin_entry import register
+
+__all__ = ["register"]

--- a/plugins/discord-presence/adapter.py
+++ b/plugins/discord-presence/adapter.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from .collector import (
+    CodexUsageSnapshot,
+    create_interruptible_codex_client,
+    fetch_codex_snapshot,
+)
+from .presence_config import PresenceConfig, load_presence_config
+from .renderer import build_custom_activity, render_presence
+
+
+logger = logging.getLogger(__name__)
+
+ConfigLoader = Callable[[], PresenceConfig]
+SnapshotFetcher = Callable[[PresenceConfig], Awaitable[CodexUsageSnapshot]]
+ActivityFactory = Callable[[str], Any]
+
+
+async def fetch_snapshot_async(config: PresenceConfig) -> CodexUsageSnapshot:
+    client = create_interruptible_codex_client()
+    worker = asyncio.create_task(
+        asyncio.to_thread(
+            fetch_codex_snapshot,
+            client_factory=lambda: client,
+            bucket_id=config.bucket_id,
+            timeout=15.0,
+        )
+    )
+    try:
+        return await asyncio.wait_for(asyncio.shield(worker), timeout=20.0)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        # asyncio.to_thread cancellation does not stop its worker. This client
+        # close kills the Codex child and wakes the pending JSON-RPC queue, then
+        # we join the worker before allowing adapter shutdown to complete.
+        client.close(timeout=0.5)
+        try:
+            await asyncio.wait_for(asyncio.shield(worker), timeout=1.0)
+        except (Exception, asyncio.CancelledError):
+            if not worker.done():
+                worker.cancel()
+            await asyncio.gather(worker, return_exceptions=True)
+        raise
+
+
+class PresenceController:
+    def __init__(
+        self,
+        client: Any,
+        *,
+        config_loader: ConfigLoader = load_presence_config,
+        snapshot_fetcher: SnapshotFetcher = fetch_snapshot_async,
+        activity_factory: ActivityFactory = build_custom_activity,
+        clock: Callable[[], float] = time.monotonic,
+        sleep_fn: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self._client = client
+        self._config_loader = config_loader
+        self._snapshot_fetcher = snapshot_fetcher
+        self._activity_factory = activity_factory
+        self._clock = clock
+        self._sleep = sleep_fn
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event = asyncio.Event()
+        self._last_text: str | None = None
+        self._last_success_at: float | None = None
+        self._has_published = False
+
+    @property
+    def task(self) -> asyncio.Task[None] | None:
+        return self._task
+
+    def _load_config(self) -> PresenceConfig:
+        try:
+            config = self._config_loader()
+        except Exception as exc:
+            logger.warning("Discord presence config read failed (%s)", type(exc).__name__)
+            return PresenceConfig()
+        return config if isinstance(config, PresenceConfig) else PresenceConfig()
+
+    async def _publish(self, text: str | None) -> bool:
+        if self._has_published and text == self._last_text:
+            return True
+        try:
+            activity = None if text is None else self._activity_factory(text)
+            await self._client.change_presence(activity=activity)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning("Discord presence update failed (%s)", type(exc).__name__)
+            return False
+        self._last_text = text
+        self._has_published = True
+        return True
+
+    async def _handle_failure(self, config: PresenceConfig) -> None:
+        now = self._clock()
+        if self._last_success_at is not None:
+            age = max(0.0, now - self._last_success_at)
+            if age <= config.stale_after_seconds:
+                return
+        await self._publish(config.fallback_text[: config.max_length])
+
+    async def refresh_once(self) -> PresenceConfig:
+        config = self._load_config()
+        if not config.enabled:
+            if self._has_published and self._last_text is not None:
+                await self._publish(None)
+            return config
+
+        try:
+            snapshot = None
+            if config.mode != "static":
+                snapshot = await self._snapshot_fetcher(config)
+            text = render_presence(snapshot, config)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning("Discord presence data unavailable (%s)", type(exc).__name__)
+            await self._handle_failure(config)
+            return config
+
+        if await self._publish(text):
+            self._last_success_at = self._clock()
+        return config
+
+    async def _run(self) -> None:
+        while not self._stop_event.is_set():
+            config = await self.refresh_once()
+            if self._stop_event.is_set():
+                break
+            sleep_task = asyncio.create_task(self._sleep(config.refresh_seconds))
+            stop_task = asyncio.create_task(self._stop_event.wait())
+            done, pending = await asyncio.wait(
+                {sleep_task, stop_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for pending_task in pending:
+                pending_task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            for completed_task in done:
+                completed_task.result()
+
+    def start(self) -> asyncio.Task[None]:
+        if self._task is None or self._task.done():
+            self._stop_event.clear()
+            self._task = asyncio.create_task(self._run(), name="discord-presence-refresh")
+        return self._task
+
+    async def stop(self) -> None:
+        task = self._task
+        self._task = None
+        if task is None:
+            return
+        self._stop_event.set()
+        try:
+            # GatewayRunner gives each adapter a five-second disconnect budget.
+            # Keep our own grace period below that budget; disconnect() runs this
+            # concurrently with the upstream Discord cleanup.
+            await asyncio.wait_for(asyncio.shield(task), timeout=3.0)
+        except asyncio.TimeoutError:
+            logger.warning("Discord presence task did not stop within timeout")
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        except asyncio.CancelledError:
+            task.cancel()
+            raise
+
+
+def create_presence_adapter_class(
+    base_adapter_class: type,
+    *,
+    config_loader: ConfigLoader = load_presence_config,
+    snapshot_fetcher: SnapshotFetcher = fetch_snapshot_async,
+    activity_factory: ActivityFactory = build_custom_activity,
+) -> type:
+    class PresenceDiscordAdapter(base_adapter_class):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            self._presence_controller: PresenceController | None = None
+
+        async def _stop_presence_controller(self) -> None:
+            controller = self._presence_controller
+            self._presence_controller = None
+            if controller is not None:
+                await controller.stop()
+
+        async def connect(self, *, is_reconnect: bool = False) -> bool:
+            await self._stop_presence_controller()
+            connected = await super().connect(is_reconnect=is_reconnect)
+            if connected and getattr(self, "_client", None) is not None:
+                self._presence_controller = PresenceController(
+                    self._client,
+                    config_loader=config_loader,
+                    snapshot_fetcher=snapshot_fetcher,
+                    activity_factory=activity_factory,
+                )
+                self._presence_controller.start()
+            return connected
+
+        async def disconnect(self) -> None:
+            controller = self._presence_controller
+            self._presence_controller = None
+            if controller is None:
+                await super().disconnect()
+                return
+
+            # Start upstream Discord cleanup immediately instead of spending
+            # its outer gateway timeout budget waiting for the Codex read.
+            results = await asyncio.gather(
+                controller.stop(),
+                super().disconnect(),
+                return_exceptions=True,
+            )
+            for result in results:
+                if isinstance(result, BaseException):
+                    raise result
+
+    PresenceDiscordAdapter.__name__ = "PresenceDiscordAdapter"
+    PresenceDiscordAdapter.__qualname__ = "PresenceDiscordAdapter"
+    return PresenceDiscordAdapter

--- a/plugins/discord-presence/collector.py
+++ b/plugins/discord-presence/collector.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Callable, Mapping
+
+
+RATE_LIMITS_READ_METHOD = "account/rateLimits/read"
+USAGE_READ_METHOD = "account/usage/read"
+READ_METHODS = frozenset({RATE_LIMITS_READ_METHOD, USAGE_READ_METHOD})
+
+
+class CollectionError(RuntimeError):
+    """A sanitized Codex usage collection failure."""
+
+
+@dataclass(frozen=True)
+class CodexUsageSnapshot:
+    used_percent: int | None = None
+    remaining_percent: int | None = None
+    reset_at: int | None = None
+    window_minutes: int | None = None
+    latest_date: str | None = None
+    latest_tokens: int | None = None
+    fetched_at: float = 0.0
+
+
+def _int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _select_rate_limit(raw: Mapping[str, Any], bucket_id: str) -> Mapping[str, Any]:
+    buckets = raw.get("rateLimitsByLimitId")
+    if isinstance(buckets, Mapping):
+        selected = buckets.get(bucket_id)
+        if isinstance(selected, Mapping):
+            return selected
+    fallback = raw.get("rateLimits")
+    return fallback if isinstance(fallback, Mapping) else {}
+
+
+def _latest_daily_bucket(raw: Mapping[str, Any]) -> tuple[str | None, int | None]:
+    buckets = raw.get("dailyUsageBuckets")
+    if not isinstance(buckets, list):
+        return None, None
+
+    valid: list[tuple[str, int]] = []
+    for bucket in buckets:
+        if not isinstance(bucket, Mapping):
+            continue
+        start_date = bucket.get("startDate")
+        tokens = _int_or_none(bucket.get("tokens"))
+        if not isinstance(start_date, str) or tokens is None or tokens < 0:
+            continue
+        try:
+            date.fromisoformat(start_date)
+        except ValueError:
+            continue
+        valid.append((start_date, tokens))
+    return max(valid, default=(None, None), key=lambda item: item[0])
+
+
+def create_interruptible_codex_client(
+    codex_bin: str = "codex",
+    *,
+    base_class: type | None = None,
+):
+    """Create a client whose close wakes synchronous pending requests.
+
+    ``CodexAppServerClient.request`` blocks on a queue. Merely cancelling the
+    asyncio wrapper does not stop that worker thread, so shutdown explicitly
+    terminates the child process and injects a sanitized error into each
+    pending queue.
+    """
+    if base_class is None:
+        from agent.transports.codex_app_server import CodexAppServerClient
+
+        base_class = CodexAppServerClient
+
+    class InterruptibleCodexAppServerClient(base_class):
+        def close(self, timeout: float = 0.5) -> None:
+            pending = []
+            lock = getattr(self, "_pending_lock", None)
+            pending_map = getattr(self, "_pending", None)
+            if lock is not None and isinstance(pending_map, dict):
+                with lock:
+                    pending = list(pending_map.values())
+                    pending_map.clear()
+            try:
+                super().close(timeout=timeout)
+            finally:
+                message = {
+                    "error": {
+                        "code": -32000,
+                        "message": "Codex usage client closed",
+                    }
+                }
+                for request in pending:
+                    try:
+                        request.queue.put_nowait(message)
+                    except Exception:
+                        pass
+
+    return InterruptibleCodexAppServerClient(codex_bin=codex_bin)
+
+
+def _default_client_factory():
+    return create_interruptible_codex_client()
+
+
+def fetch_codex_snapshot(
+    client_factory: Callable[[], Any] | None = None,
+    *,
+    bucket_id: str = "codex",
+    timeout: float = 15.0,
+    now_fn: Callable[[], float] = time.time,
+) -> CodexUsageSnapshot:
+    factory = client_factory or _default_client_factory
+    try:
+        with factory() as client:
+            client.initialize(
+                client_name="hermes-discord-presence",
+                client_title="Hermes Discord Presence",
+                client_version="1.0.1",
+            )
+            rate_limits = client.request(RATE_LIMITS_READ_METHOD, timeout=timeout)
+            usage = client.request(USAGE_READ_METHOD, timeout=timeout)
+    except Exception as exc:
+        raise CollectionError(f"{type(exc).__name__}: Codex usage read failed") from None
+
+    if not isinstance(rate_limits, Mapping):
+        rate_limits = {}
+    if not isinstance(usage, Mapping):
+        usage = {}
+
+    selected = _select_rate_limit(rate_limits, bucket_id)
+    primary = selected.get("primary") if isinstance(selected, Mapping) else None
+    if not isinstance(primary, Mapping):
+        primary = {}
+
+    used = _int_or_none(primary.get("usedPercent"))
+    if used is not None:
+        used = min(100, max(0, used))
+    remaining = None if used is None else 100 - used
+    latest_date, latest_tokens = _latest_daily_bucket(usage)
+
+    return CodexUsageSnapshot(
+        used_percent=used,
+        remaining_percent=remaining,
+        reset_at=_int_or_none(primary.get("resetsAt")),
+        window_minutes=_int_or_none(primary.get("windowDurationMins")),
+        latest_date=latest_date,
+        latest_tokens=latest_tokens,
+        fetched_at=float(now_fn()),
+    )

--- a/plugins/discord-presence/plugin.yaml
+++ b/plugins/discord-presence/plugin.yaml
@@ -1,0 +1,12 @@
+name: discord-presence
+label: Discord Codex Usage Presence
+kind: platform
+version: 1.0.1
+description: >
+  Adds a plain-text Discord Custom Activity showing read-only Codex usage data.
+  Extends the bundled Discord adapter without modifying Hermes core files.
+author: local
+requires_env:
+  - name: DISCORD_BOT_TOKEN
+    description: Discord bot token used by the existing Discord platform
+    password: true

--- a/plugins/discord-presence/plugin_entry.py
+++ b/plugins/discord-presence/plugin_entry.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .adapter import create_presence_adapter_class
+
+
+def install_upstream_override(ctx: Any, *, upstream_module: Any = None) -> type:
+    if upstream_module is None:
+        from plugins.platforms.discord import adapter as upstream_module
+
+    current_class = upstream_module.DiscordAdapter
+    if getattr(current_class, "_discord_presence_plugin", False):
+        installed_class = current_class
+    else:
+        installed_class = create_presence_adapter_class(current_class)
+        installed_class._discord_presence_plugin = True
+        upstream_module.DiscordAdapter = installed_class
+
+    upstream_module.register(ctx)
+    return installed_class
+
+
+def register(ctx: Any) -> None:
+    install_upstream_override(ctx)

--- a/plugins/discord-presence/presence_config.py
+++ b/plugins/discord-presence/presence_config.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping
+
+
+SUPPORTED_MODES = frozenset({"rate_limit", "daily_tokens", "combined", "static"})
+DEFAULT_TEMPLATE = "Codex残量 {remaining_percent}%｜次回リセット {reset_time_jst}"
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _as_int(value: Any, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True)
+class PresenceConfig:
+    enabled: bool = False
+    mode: str = "rate_limit"
+    template: str = DEFAULT_TEMPLATE
+    bucket_id: str = "codex"
+    refresh_seconds: int = 300
+    stale_after_seconds: int = 900
+    fallback_text: str = "Codex利用量 取得待ち"
+    timezone: str = "Asia/Tokyo"
+    max_length: int = 120
+    static_text: str = "Hermes"
+    validation_errors: tuple[str, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any] | None) -> "PresenceConfig":
+        if not isinstance(raw, Mapping):
+            return cls()
+
+        errors: list[str] = []
+        mode_value = str(raw.get("mode", cls.mode)).strip().lower()
+        if mode_value not in SUPPORTED_MODES:
+            errors.append(f"unsupported mode: {mode_value}")
+            mode_value = cls.mode
+
+        refresh = max(60, _as_int(raw.get("refresh_seconds"), cls.refresh_seconds))
+        stale = max(refresh, _as_int(raw.get("stale_after_seconds"), cls.stale_after_seconds))
+        max_length = min(120, max(1, _as_int(raw.get("max_length"), cls.max_length)))
+
+        return cls(
+            enabled=_as_bool(raw.get("enabled"), cls.enabled),
+            mode=mode_value,
+            template=str(raw.get("template", cls.template)),
+            bucket_id=str(raw.get("bucket_id", cls.bucket_id)).strip() or cls.bucket_id,
+            refresh_seconds=refresh,
+            stale_after_seconds=stale,
+            fallback_text=str(raw.get("fallback_text", cls.fallback_text)),
+            timezone=str(raw.get("timezone", cls.timezone)).strip() or cls.timezone,
+            max_length=max_length,
+            static_text=str(raw.get("static_text", cls.static_text)),
+            validation_errors=tuple(errors),
+        )
+
+
+def load_presence_config(
+    config_loader: Callable[[], Mapping[str, Any]] | None = None,
+) -> PresenceConfig:
+    if config_loader is None:
+        from hermes_cli.config import load_config
+
+        config_loader = load_config
+
+    try:
+        root = config_loader()
+    except Exception:
+        return PresenceConfig()
+    if not isinstance(root, Mapping):
+        return PresenceConfig()
+    discord_cfg = root.get("discord")
+    if not isinstance(discord_cfg, Mapping):
+        return PresenceConfig()
+    presence_cfg = discord_cfg.get("presence")
+    if not isinstance(presence_cfg, Mapping):
+        return PresenceConfig()
+    return PresenceConfig.from_mapping(presence_cfg)

--- a/plugins/discord-presence/renderer.py
+++ b/plugins/discord-presence/renderer.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from string import Formatter
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from .collector import CodexUsageSnapshot
+from .presence_config import PresenceConfig
+
+
+ALLOWED_PLACEHOLDERS = frozenset(
+    {
+        "remaining_percent",
+        "used_percent",
+        "reset_time_jst",
+        "window_minutes",
+        "latest_date",
+        "latest_tokens",
+        "latest_tokens_short",
+    }
+)
+
+
+class RenderError(ValueError):
+    """A safe rendering failure that contains no account data."""
+
+
+def format_tokens(tokens: int | None) -> str:
+    if tokens is None:
+        return "?"
+    value = max(0, int(tokens))
+    for divisor, suffix in ((1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K")):
+        if value >= divisor:
+            number = value / divisor
+            rendered = f"{number:.1f}".rstrip("0").rstrip(".")
+            return f"{rendered}{suffix}"
+    return str(value)
+
+
+def _reset_time(reset_at: int | None, timezone_name: str) -> str:
+    if reset_at is None:
+        return "?"
+    try:
+        zone = ZoneInfo(timezone_name)
+        instant = datetime.fromtimestamp(reset_at, tz=timezone.utc).astimezone(zone)
+    except (ValueError, OverflowError, OSError, ZoneInfoNotFoundError):
+        raise RenderError("invalid reset time or timezone") from None
+    return instant.strftime("%m/%d %H:%M")
+
+
+def _validate_template(template: str) -> None:
+    try:
+        parsed = Formatter().parse(template)
+        for _, field_name, format_spec, conversion in parsed:
+            if field_name is None:
+                continue
+            if field_name not in ALLOWED_PLACEHOLDERS or format_spec or conversion:
+                raise RenderError("unsupported template placeholder")
+    except ValueError as exc:
+        if isinstance(exc, RenderError):
+            raise
+        raise RenderError("invalid template") from None
+
+
+def render_presence(snapshot: CodexUsageSnapshot | None, config: PresenceConfig) -> str:
+    if config.mode == "static":
+        return config.static_text[: config.max_length]
+    if snapshot is None:
+        raise RenderError("usage snapshot unavailable")
+
+    _validate_template(config.template)
+    values = {
+        "remaining_percent": "?" if snapshot.remaining_percent is None else snapshot.remaining_percent,
+        "used_percent": "?" if snapshot.used_percent is None else snapshot.used_percent,
+        "reset_time_jst": _reset_time(snapshot.reset_at, config.timezone),
+        "window_minutes": "?" if snapshot.window_minutes is None else snapshot.window_minutes,
+        "latest_date": snapshot.latest_date or "?",
+        "latest_tokens": "?" if snapshot.latest_tokens is None else snapshot.latest_tokens,
+        "latest_tokens_short": format_tokens(snapshot.latest_tokens),
+    }
+    try:
+        text = config.template.format_map(values)
+    except (KeyError, ValueError):
+        raise RenderError("invalid template") from None
+    return text[: config.max_length]
+
+
+def build_custom_activity(text: str):
+    import discord
+
+    return discord.CustomActivity(name=text)

--- a/plugins/discord-presence/tests/conftest.py
+++ b/plugins/discord-presence/tests/conftest.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+HERMES_ROOT = Path("/opt/hermes")
+PACKAGE_NAME = "discord_presence_plugin"
+
+if HERMES_ROOT.is_dir() and str(HERMES_ROOT) not in sys.path:
+    sys.path.insert(0, str(HERMES_ROOT))
+
+if PACKAGE_NAME not in sys.modules:
+    package = types.ModuleType(PACKAGE_NAME)
+    package.__path__ = [str(PLUGIN_ROOT)]
+    package.__package__ = PACKAGE_NAME
+    sys.modules[PACKAGE_NAME] = package

--- a/plugins/discord-presence/tests/test_adapter.py
+++ b/plugins/discord-presence/tests/test_adapter.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import unittest
+from unittest.mock import AsyncMock, patch
+
+import conftest  # noqa: F401
+from discord_presence_plugin.adapter import (
+    PresenceController,
+    create_presence_adapter_class,
+    fetch_snapshot_async,
+)
+from discord_presence_plugin.collector import CodexUsageSnapshot
+from discord_presence_plugin.presence_config import PresenceConfig
+
+
+class PresenceControllerTest(unittest.IsolatedAsyncioTestCase):
+    async def test_async_fetch_cancellation_closes_client_and_joins_worker(self):
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+
+        class FakeClient:
+            closed = False
+
+            def close(self, timeout=0.5):
+                self.closed = True
+                release.set()
+
+        client = FakeClient()
+
+        def blocking_fetch(*, client_factory, **_kwargs):
+            self.assertIs(client_factory(), client)
+            started.set()
+            release.wait(timeout=2)
+            finished.set()
+            return CodexUsageSnapshot(remaining_percent=50)
+
+        with (
+            patch(
+                "discord_presence_plugin.adapter.create_interruptible_codex_client",
+                return_value=client,
+                create=True,
+            ),
+            patch(
+                "discord_presence_plugin.adapter.fetch_codex_snapshot",
+                side_effect=blocking_fetch,
+            ),
+        ):
+            task = asyncio.create_task(fetch_snapshot_async(PresenceConfig(enabled=True)))
+            await asyncio.to_thread(started.wait, 1)
+            task.cancel()
+            try:
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+                self.assertTrue(client.closed)
+                self.assertTrue(finished.is_set())
+            finally:
+                release.set()
+                await asyncio.to_thread(finished.wait, 1)
+
+    async def test_updates_changed_text_and_suppresses_duplicate(self):
+        client = type("Client", (), {"change_presence": AsyncMock()})()
+        cfg = PresenceConfig(enabled=True, template="Codex {remaining_percent}%")
+
+        async def fetch(_cfg):
+            return CodexUsageSnapshot(remaining_percent=73, fetched_at=10)
+
+        controller = PresenceController(
+            client,
+            config_loader=lambda: cfg,
+            snapshot_fetcher=fetch,
+            activity_factory=lambda text: f"activity:{text}",
+            clock=lambda: 10,
+        )
+
+        await controller.refresh_once()
+        await controller.refresh_once()
+
+        client.change_presence.assert_awaited_once_with(activity="activity:Codex 73%")
+
+    async def test_keeps_previous_value_until_stale_then_uses_fallback(self):
+        client = type("Client", (), {"change_presence": AsyncMock()})()
+        cfg = PresenceConfig(
+            enabled=True,
+            template="Codex {remaining_percent}%",
+            stale_after_seconds=900,
+            fallback_text="waiting",
+        )
+        now = [0.0]
+        fail = [False]
+
+        async def fetch(_cfg):
+            if fail[0]:
+                raise RuntimeError("secret response")
+            return CodexUsageSnapshot(remaining_percent=73)
+
+        controller = PresenceController(
+            client,
+            config_loader=lambda: cfg,
+            snapshot_fetcher=fetch,
+            activity_factory=lambda text: text,
+            clock=lambda: now[0],
+        )
+        await controller.refresh_once()
+        fail[0] = True
+        now[0] = 100
+        with self.assertLogs("discord_presence_plugin.adapter", level="WARNING"):
+            await controller.refresh_once()
+        self.assertEqual(client.change_presence.await_count, 1)
+
+        now[0] = 901
+        with self.assertLogs("discord_presence_plugin.adapter", level="WARNING"):
+            await controller.refresh_once()
+        self.assertEqual(client.change_presence.await_count, 2)
+        client.change_presence.assert_awaited_with(activity="waiting")
+
+    async def test_initial_failure_uses_fallback_and_does_not_leak_exception(self):
+        client = type("Client", (), {"change_presence": AsyncMock()})()
+        cfg = PresenceConfig(enabled=True, fallback_text="waiting")
+
+        async def fetch(_cfg):
+            raise RuntimeError("oauth=super-secret")
+
+        controller = PresenceController(
+            client,
+            config_loader=lambda: cfg,
+            snapshot_fetcher=fetch,
+            activity_factory=lambda text: text,
+        )
+
+        with self.assertLogs("discord_presence_plugin.adapter", level="WARNING") as logs:
+            await controller.refresh_once()
+
+        client.change_presence.assert_awaited_once_with(activity="waiting")
+        self.assertNotIn("super-secret", "\n".join(logs.output))
+
+    async def test_disabling_clears_activity_only_once(self):
+        client = type("Client", (), {"change_presence": AsyncMock()})()
+        cfg = [PresenceConfig(enabled=True, mode="static", static_text="ready")]
+
+        async def unused(_cfg):
+            self.fail("collector should not run in static mode")
+
+        controller = PresenceController(
+            client,
+            config_loader=lambda: cfg[0],
+            snapshot_fetcher=unused,
+            activity_factory=lambda text: text,
+        )
+        await controller.refresh_once()
+        cfg[0] = PresenceConfig(enabled=False)
+        await controller.refresh_once()
+        await controller.refresh_once()
+
+        self.assertEqual(client.change_presence.await_count, 2)
+        client.change_presence.assert_awaited_with(activity=None)
+
+    async def test_failed_discord_update_is_retried(self):
+        change_presence = AsyncMock(side_effect=[RuntimeError("network"), None])
+        client = type("Client", (), {"change_presence": change_presence})()
+        cfg = PresenceConfig(enabled=True, mode="static", static_text="ready")
+        controller = PresenceController(
+            client,
+            config_loader=lambda: cfg,
+            snapshot_fetcher=AsyncMock(),
+            activity_factory=lambda text: text,
+        )
+
+        with self.assertLogs("discord_presence_plugin.adapter", level="WARNING"):
+            await controller.refresh_once()
+        await controller.refresh_once()
+
+        self.assertEqual(change_presence.await_count, 2)
+
+    async def test_start_is_idempotent_and_stop_cancels_task(self):
+        client = type("Client", (), {"change_presence": AsyncMock()})()
+        cfg = PresenceConfig(enabled=True, mode="static", static_text="ready", refresh_seconds=60)
+        sleeping = asyncio.Event()
+
+        async def sleep(_seconds):
+            sleeping.set()
+            await asyncio.Future()
+
+        controller = PresenceController(
+            client,
+            config_loader=lambda: cfg,
+            snapshot_fetcher=AsyncMock(),
+            activity_factory=lambda text: text,
+            sleep_fn=sleep,
+        )
+
+        first = controller.start()
+        second = controller.start()
+        await asyncio.wait_for(sleeping.wait(), timeout=1)
+
+        self.assertIs(first, second)
+        self.assertFalse(first.done())
+        await controller.stop()
+        self.assertTrue(first.done())
+        self.assertIsNone(controller.task)
+
+    async def test_stop_waits_for_inflight_fetch_to_finish_cleanly(self):
+        client = type("Client", (), {"change_presence": AsyncMock()})()
+        cfg = PresenceConfig(enabled=True, template="Codex {remaining_percent}%")
+        started = asyncio.Event()
+        release = asyncio.Event()
+        cancelled = [False]
+
+        async def fetch(_cfg):
+            started.set()
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                cancelled[0] = True
+                raise
+            return CodexUsageSnapshot(remaining_percent=73)
+
+        controller = PresenceController(
+            client,
+            config_loader=lambda: cfg,
+            snapshot_fetcher=fetch,
+            activity_factory=lambda text: text,
+        )
+        controller.start()
+        await asyncio.wait_for(started.wait(), timeout=1)
+
+        stop_task = asyncio.create_task(controller.stop())
+        await asyncio.sleep(0)
+        self.assertFalse(stop_task.done())
+
+        release.set()
+        await asyncio.wait_for(stop_task, timeout=1)
+        self.assertFalse(cancelled[0])
+        self.assertIsNone(controller.task)
+
+
+class BaseAdapter:
+    def __init__(self, config):
+        self.config = config
+        self._client = type("Client", (), {"change_presence": AsyncMock()})()
+        self.connected = False
+        self.is_reconnect = None
+        self.disconnected = False
+
+    async def connect(self, *, is_reconnect=False):
+        self.connected = True
+        self.is_reconnect = is_reconnect
+        return True
+
+    async def disconnect(self):
+        self.disconnected = True
+
+
+class PresenceAdapterLifecycleTest(unittest.IsolatedAsyncioTestCase):
+    async def test_connect_starts_one_controller_and_disconnect_stops_it(self):
+        cfg = PresenceConfig(enabled=True, mode="static", static_text="ready")
+        adapter_cls = create_presence_adapter_class(
+            BaseAdapter,
+            config_loader=lambda: cfg,
+            snapshot_fetcher=AsyncMock(),
+            activity_factory=lambda text: text,
+        )
+        adapter = adapter_cls(config={})
+
+        self.assertTrue(await adapter.connect(is_reconnect=True))
+        self.assertTrue(adapter.is_reconnect)
+        first_task = adapter._presence_controller.task
+        self.assertTrue(await adapter.connect(is_reconnect=True))
+        second_task = adapter._presence_controller.task
+
+        self.assertIsNot(first_task, second_task)
+        self.assertTrue(first_task.done())
+        await adapter.disconnect()
+        self.assertTrue(second_task.done())
+        self.assertTrue(adapter.disconnected)
+
+    async def test_disconnect_starts_base_cleanup_without_waiting_for_presence(self):
+        adapter_cls = create_presence_adapter_class(BaseAdapter)
+        adapter = adapter_cls(config={})
+        stop_started = asyncio.Event()
+        release_stop = asyncio.Event()
+
+        class SlowController:
+            async def stop(self):
+                stop_started.set()
+                await release_stop.wait()
+
+        adapter._presence_controller = SlowController()
+        disconnect_task = asyncio.create_task(adapter.disconnect())
+        await asyncio.wait_for(stop_started.wait(), timeout=1)
+        await asyncio.sleep(0)
+
+        self.assertTrue(adapter.disconnected)
+        self.assertFalse(disconnect_task.done())
+        release_stop.set()
+        await asyncio.wait_for(disconnect_task, timeout=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/discord-presence/tests/test_collector.py
+++ b/plugins/discord-presence/tests/test_collector.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import queue
+import threading
+from types import SimpleNamespace
+import unittest
+
+import conftest  # noqa: F401
+from discord_presence_plugin.collector import (
+    CollectionError,
+    create_interruptible_codex_client,
+    fetch_codex_snapshot,
+)
+
+
+class FakeClient:
+    def __init__(self, responses=None, error=None):
+        self.responses = responses or {}
+        self.error = error
+        self.calls = []
+        self.closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.closed = True
+
+    def initialize(self, **kwargs):
+        self.calls.append(("initialize", kwargs))
+        return {"ok": True}
+
+    def request(self, method, timeout):
+        self.calls.append((method, timeout))
+        if self.error:
+            raise self.error
+        return self.responses[method]
+
+
+class CodexCollectorTest(unittest.TestCase):
+    def test_interruptible_client_close_wakes_pending_requests(self):
+        class BaseClient:
+            def __init__(self, codex_bin):
+                self.codex_bin = codex_bin
+                self._closed = False
+                self._pending_lock = threading.Lock()
+                self.pending = SimpleNamespace(queue=queue.Queue(maxsize=1))
+                self._pending = {1: self.pending}
+                self.close_timeout = None
+
+            def close(self, timeout=3.0):
+                self.close_timeout = timeout
+                self._closed = True
+
+        client = create_interruptible_codex_client(
+            codex_bin="codex-test",
+            base_class=BaseClient,
+        )
+        client.close(timeout=0.25)
+
+        message = client.pending.queue.get_nowait()
+        self.assertIn("error", message)
+        self.assertEqual(client._pending, {})
+        self.assertEqual(client.close_timeout, 0.25)
+
+    def test_reads_only_usage_endpoints_and_closes_client(self):
+        client = FakeClient(
+            {
+                "account/rateLimits/read": {
+                    "rateLimits": {"primary": {"usedPercent": 25, "resetsAt": 123, "windowDurationMins": 300}}
+                },
+                "account/usage/read": {"dailyUsageBuckets": []},
+            }
+        )
+
+        snapshot = fetch_codex_snapshot(lambda: client, now_fn=lambda: 456.0)
+
+        self.assertEqual(
+            [call[0] for call in client.calls],
+            ["initialize", "account/rateLimits/read", "account/usage/read"],
+        )
+        self.assertTrue(client.closed)
+        self.assertEqual(snapshot.used_percent, 25)
+        self.assertEqual(snapshot.remaining_percent, 75)
+        self.assertEqual(snapshot.fetched_at, 456.0)
+
+    def test_prefers_requested_multi_bucket(self):
+        client = FakeClient(
+            {
+                "account/rateLimits/read": {
+                    "rateLimits": {"primary": {"usedPercent": 90}},
+                    "rateLimitsByLimitId": {
+                        "codex": {"primary": {"usedPercent": 12, "resetsAt": 987}}
+                    },
+                },
+                "account/usage/read": {"dailyUsageBuckets": []},
+            }
+        )
+
+        snapshot = fetch_codex_snapshot(lambda: client, bucket_id="codex")
+
+        self.assertEqual(snapshot.used_percent, 12)
+        self.assertEqual(snapshot.remaining_percent, 88)
+        self.assertEqual(snapshot.reset_at, 987)
+
+    def test_clamps_percent_and_handles_missing_primary(self):
+        high = FakeClient(
+            {
+                "account/rateLimits/read": {"rateLimits": {"primary": {"usedPercent": 170}}},
+                "account/usage/read": {"dailyUsageBuckets": []},
+            }
+        )
+        missing = FakeClient(
+            {
+                "account/rateLimits/read": {"rateLimits": {}},
+                "account/usage/read": {"dailyUsageBuckets": []},
+            }
+        )
+
+        self.assertEqual(fetch_codex_snapshot(lambda: high).remaining_percent, 0)
+        self.assertIsNone(fetch_codex_snapshot(lambda: missing).remaining_percent)
+
+    def test_selects_latest_valid_daily_bucket(self):
+        client = FakeClient(
+            {
+                "account/rateLimits/read": {"rateLimits": {"primary": {"usedPercent": 0}}},
+                "account/usage/read": {
+                    "dailyUsageBuckets": [
+                        {"startDate": "2026-07-28", "tokens": 100},
+                        {"startDate": "bad", "tokens": "oops"},
+                        {"startDate": "2026-07-30", "tokens": 1234567},
+                        {"startDate": "2026-07-29", "tokens": 200},
+                    ]
+                },
+            }
+        )
+
+        snapshot = fetch_codex_snapshot(lambda: client)
+
+        self.assertEqual(snapshot.latest_date, "2026-07-30")
+        self.assertEqual(snapshot.latest_tokens, 1234567)
+
+    def test_hides_sensitive_exception_text(self):
+        client = FakeClient(error=RuntimeError("oauth_token=super-secret-value"))
+
+        with self.assertRaises(CollectionError) as caught:
+            fetch_codex_snapshot(lambda: client)
+
+        message = str(caught.exception)
+        self.assertIn("RuntimeError", message)
+        self.assertNotIn("super-secret-value", message)
+        self.assertTrue(client.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/discord-presence/tests/test_config.py
+++ b/plugins/discord-presence/tests/test_config.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import unittest
+
+import conftest  # noqa: F401 - installs the isolated package alias
+from discord_presence_plugin.presence_config import PresenceConfig, load_presence_config
+
+
+class PresenceConfigTest(unittest.TestCase):
+    def test_defaults_are_safe_and_disabled(self):
+        cfg = PresenceConfig.from_mapping({})
+
+        self.assertFalse(cfg.enabled)
+        self.assertEqual(cfg.mode, "rate_limit")
+        self.assertEqual(cfg.refresh_seconds, 300)
+        self.assertEqual(cfg.stale_after_seconds, 900)
+        self.assertEqual(cfg.max_length, 120)
+        self.assertEqual(cfg.timezone, "Asia/Tokyo")
+
+    def test_unsafe_numeric_values_are_clamped(self):
+        cfg = PresenceConfig.from_mapping(
+            {
+                "refresh_seconds": 1,
+                "stale_after_seconds": 2,
+                "max_length": 999,
+            }
+        )
+
+        self.assertEqual(cfg.refresh_seconds, 60)
+        self.assertEqual(cfg.stale_after_seconds, 60)
+        self.assertEqual(cfg.max_length, 120)
+
+    def test_unknown_mode_falls_back_without_crashing(self):
+        cfg = PresenceConfig.from_mapping({"mode": "mystery"})
+
+        self.assertEqual(cfg.mode, "rate_limit")
+        self.assertEqual(cfg.validation_errors, ("unsupported mode: mystery",))
+
+    def test_load_presence_config_reads_fresh_mapping_each_time(self):
+        values = [
+            {"discord": {"presence": {"enabled": False, "template": "first"}}},
+            {"discord": {"presence": {"enabled": True, "template": "second"}}},
+        ]
+
+        first = load_presence_config(lambda: values.pop(0))
+        second = load_presence_config(lambda: values.pop(0))
+
+        self.assertFalse(first.enabled)
+        self.assertEqual(first.template, "first")
+        self.assertTrue(second.enabled)
+        self.assertEqual(second.template, "second")
+
+    def test_invalid_top_level_shape_falls_back_to_defaults(self):
+        cfg = load_presence_config(lambda: {"discord": {"presence": "bad"}})
+
+        self.assertEqual(cfg, PresenceConfig())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/discord-presence/tests/test_plugin_entry.py
+++ b/plugins/discord-presence/tests/test_plugin_entry.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import types
+import unittest
+
+import conftest  # noqa: F401
+from discord_presence_plugin.plugin_entry import install_upstream_override
+
+
+class ExistingDiscordAdapter:
+    recovery_feature = True
+
+    def __init__(self, config):
+        self.config = config
+        self._client = None
+
+    async def connect(self, token):
+        return True
+
+    async def disconnect(self):
+        return None
+
+
+class FakeContext:
+    def __init__(self):
+        self.calls = []
+
+
+class PluginEntryTest(unittest.TestCase):
+    def test_wraps_current_upstream_adapter_and_reuses_registration(self):
+        context = FakeContext()
+        upstream = types.SimpleNamespace(DiscordAdapter=ExistingDiscordAdapter)
+
+        def register(ctx):
+            ctx.calls.append(upstream.DiscordAdapter)
+
+        upstream.register = register
+
+        installed = install_upstream_override(context, upstream_module=upstream)
+
+        self.assertIs(upstream.DiscordAdapter, installed)
+        self.assertTrue(issubclass(installed, ExistingDiscordAdapter))
+        self.assertTrue(installed.recovery_feature)
+        self.assertEqual(context.calls, [installed])
+
+    def test_install_is_idempotent(self):
+        context = FakeContext()
+        upstream = types.SimpleNamespace(DiscordAdapter=ExistingDiscordAdapter)
+
+        def register(ctx):
+            ctx.calls.append(upstream.DiscordAdapter)
+
+        upstream.register = register
+
+        first = install_upstream_override(context, upstream_module=upstream)
+        second = install_upstream_override(context, upstream_module=upstream)
+
+        self.assertIs(first, second)
+        self.assertEqual(context.calls, [first, first])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/discord-presence/tests/test_renderer.py
+++ b/plugins/discord-presence/tests/test_renderer.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+import conftest  # noqa: F401
+from discord_presence_plugin.collector import CodexUsageSnapshot
+from discord_presence_plugin.presence_config import PresenceConfig
+from discord_presence_plugin.renderer import RenderError, build_custom_activity, format_tokens, render_presence
+
+
+class PresenceRendererTest(unittest.TestCase):
+    def test_renders_rate_limit_and_reset_date_time_in_jst(self):
+        reset_at = int(datetime(2026, 7, 30, 9, 0, tzinfo=timezone.utc).timestamp())
+        snapshot = CodexUsageSnapshot(
+            used_percent=27,
+            remaining_percent=73,
+            reset_at=reset_at,
+            window_minutes=300,
+        )
+        cfg = PresenceConfig(enabled=True)
+
+        text = render_presence(snapshot, cfg)
+
+        self.assertEqual(text, "Codex残量 73%｜次回リセット 07/30 18:00")
+
+    def test_formats_compact_token_counts(self):
+        self.assertEqual(format_tokens(999), "999")
+        self.assertEqual(format_tokens(1_200), "1.2K")
+        self.assertEqual(format_tokens(1_234_567), "1.2M")
+        self.assertEqual(format_tokens(2_000_000_000), "2B")
+
+    def test_daily_token_placeholders_are_whitelisted(self):
+        snapshot = CodexUsageSnapshot(latest_date="2026-07-30", latest_tokens=1_234_567)
+        cfg = PresenceConfig(
+            enabled=True,
+            mode="daily_tokens",
+            template="Codex {latest_date} {latest_tokens_short} tok",
+        )
+
+        text = render_presence(snapshot, cfg)
+
+        self.assertEqual(text, "Codex 2026-07-30 1.2M tok")
+
+    def test_unknown_placeholder_fails_without_echoing_snapshot_metadata(self):
+        snapshot = CodexUsageSnapshot(remaining_percent=73)
+        cfg = PresenceConfig(enabled=True, template="{account_id}")
+
+        with self.assertRaises(RenderError) as caught:
+            render_presence(snapshot, cfg)
+
+        self.assertEqual(str(caught.exception), "unsupported template placeholder")
+
+    def test_truncates_without_exceeding_configured_length(self):
+        snapshot = CodexUsageSnapshot(remaining_percent=73)
+        cfg = PresenceConfig(enabled=True, template="x" * 200, max_length=20)
+
+        self.assertEqual(render_presence(snapshot, cfg), "x" * 20)
+
+    def test_static_mode_does_not_require_codex_values(self):
+        cfg = PresenceConfig(enabled=True, mode="static", static_text="Hermes ready")
+
+        self.assertEqual(render_presence(None, cfg), "Hermes ready")
+
+    def test_builds_discord_custom_activity_type_four(self):
+        activity = build_custom_activity("Codex残量 73%")
+
+        payload = activity.to_dict()
+        self.assertEqual(payload["type"], 4)
+        self.assertEqual(payload["state"], "Codex残量 73%")
+        self.assertEqual(payload["name"], "Custom Status")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the versioned `discord-presence` Hermes plugin source and deployment runbook
- read content-free Codex usage/rate-limit data and render it as Discord Custom Activity
- show the weekly reset as `次回リセット MM/DD HH:MM` in JST
- keep the plugin disabled by default, with configurable refresh and stale-value windows
- avoid prompts, responses, conversation history, logs, raw responses, and credentials

## Validation

- compiled all 12 Python source/test files successfully
- ran all 30 unit tests successfully in a network-disabled temporary container using the deployed Hermes image
- verified the staged diff contains exactly 15 files under `plugins/discord-presence/`
- passed `git diff --cached --check`
- found no committed private identity, server-specific home path, long Discord-style identifier, bearer token, or private-key marker

## Deployment status

Version 1.0.1 is already deployed on the owashota instance with a 15-minute refresh and 45-minute stale window through ignored runtime configuration. The owner confirmed the visible Discord date display. This PR contains source and sanitized documentation only; it does not commit runtime configuration, usage values, identifiers, or secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in Discord Custom Activity showing read-only Codex usage, limits, reset times, and configurable status templates.
  * Supports static or dynamic display modes, stale-data fallbacks, automatic refresh, duplicate suppression, and reconnect handling.
  * Preserves normal Discord functionality when usage retrieval or presence updates fail.

* **Documentation**
  * Added installation, configuration, deployment, troubleshooting, validation, and rollback guidance.

* **Tests**
  * Added comprehensive coverage for collection, rendering, configuration, lifecycle behavior, error handling, and installation safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->